### PR TITLE
Preparing for publication on CRAN

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -20,7 +20,6 @@ jobs:
         config:
           - {os: macos-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
-          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,5 +41,5 @@ Suggests:
     testthat (>= 3.0.0),
     tibble
 Language: en-US
-URL: https://rasmusskytte.github.io/SCDB/
+URL: https://ssi-dk.github.io/SCDB/
 Config/testthat/edition: 3

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# SCDB <a href="https://rasmusskytte.github.io/SCDB/"><img src="man/figures/logo.png" align="right" height="138" alt="SCDB website" /></a>
-[![R-CMD-check](https://github.com/rasmusskytte/SCDB/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/rasmusskytte/SCDB/actions/workflows/R-CMD-check.yaml)
-[![Codecov test coverage](https://codecov.io/gh/rasmusskytte/SCDB/branch/main/graph/badge.svg)](https://app.codecov.io/gh/rasmusskytte/SCDB?branch=main)
+# SCDB <a href="https://ssi-dk.github.io/SCDB/"><img src="man/figures/logo.png" align="right" height="138" alt="SCDB website" /></a>
+[![R-CMD-check](https://github.com/ssi-dk.SCDB/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/ssi-dk.SCDB/actions/workflows/R-CMD-check.yaml)
+[![Codecov test coverage](https://codecov.io/gh/ssi-dk.SCDB/branch/main/graph/badge.svg)](https://app.codecov.io/gh/ssi-dk.SCDB?branch=main)
 
 
 R package for maintaining data bases with slowly-changing-dimensions

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,4 @@
-url: https://rasmusskytte.github.io/SCDB/
+url: https://ssi-dk.github.io/SCDB/
 template:
   bootstrap: 5
 

--- a/man/SCDB-package.Rd
+++ b/man/SCDB-package.Rd
@@ -13,7 +13,7 @@ This package contains scripts for easily accessing and updating a database of da
 \seealso{
 Useful links:
 \itemize{
-  \item \url{https://rasmusskytte.github.io/SCDB/}
+  \item \url{https://ssi-dk.github.io/SCDB/}
 }
 
 }


### PR DESCRIPTION
This PR removes the slow ubuntu-latest-devel from the R-CMD-check workflow and changes urls to point to ssi-dk in anticipation of a migration to that github org.