### PR TITLE
Increase coverage in several files

### DIFF
--- a/R/get_table.R
+++ b/R/get_table.R
@@ -32,7 +32,7 @@ get_table <- function(conn, db_table_id = NULL, slice_ts = NA, include_slice_inf
 
   # Get tables in db schema
   if (is.null(db_table_id)) {
-    print("Select one the following tables:")
+    print("Select one of the following tables:")
     return(get_tables(conn))
   }
 

--- a/tests/testthat/test-Logger.R
+++ b/tests/testthat/test-Logger.R
@@ -120,3 +120,29 @@ test_that("Logger works", { for (conn in conns) { # nolint: brace_linter
     purrr::keep(~ endsWith(., ".log")) |>
     purrr::walk(~ unlink(file.path(log_path, .)))
 }})
+
+test_that("Logger stops if file exists", { for (conn in conns){
+  db_tablestring <- "test.SCDB_logger"
+  ts <- Sys.time()
+  log_path <- tempdir()
+  logger <- Logger$new(
+      db_tablestring = db_tablestring,
+      ts = ts,
+      log_table_id = NULL,
+      log_path = log_path
+  )
+
+  utils::capture.output(logger$log_info("test message"))
+
+  expect_error(
+    logger2 <- Logger$new(
+      db_tablestring = db_tablestring,
+      ts = ts,
+      start_time = ts,
+      log_table_id = NULL,
+      log_path = log_path
+    )
+  )
+
+  file.remove(file.path(log_path, logger$log_filename))
+}})

--- a/tests/testthat/test-Logger.R
+++ b/tests/testthat/test-Logger.R
@@ -121,15 +121,15 @@ test_that("Logger works", { for (conn in conns) { # nolint: brace_linter
     purrr::walk(~ unlink(file.path(log_path, .)))
 }})
 
-test_that("Logger stops if file exists", { for (conn in conns){
+test_that("Logger stops if file exists", { for (conn in conns) { # nolint: brace_linter
   db_tablestring <- "test.SCDB_logger"
   ts <- Sys.time()
   log_path <- tempdir()
   logger <- Logger$new(
-      db_tablestring = db_tablestring,
-      ts = ts,
-      log_table_id = NULL,
-      log_path = log_path
+    db_tablestring = db_tablestring,
+    ts = ts,
+    log_table_id = NULL,
+    log_path = log_path
   )
 
   utils::capture.output(logger$log_info("test message"))

--- a/tests/testthat/test-db_timestamp.R
+++ b/tests/testthat/test-db_timestamp.R
@@ -7,7 +7,7 @@ test_that("db_timestamp produce consistent results", { for (conn in conns) { # n
     db_timestamp(ts_str, conn)
   )
 
-  # Test using NULL conn to trigger
+  # Test default fallback
   expect_identical(
     db_timestamp.default(ts_posix, conn = NULL),
     db_timestamp.default(ts_str, conn = NULL)

--- a/tests/testthat/test-db_timestamp.R
+++ b/tests/testthat/test-db_timestamp.R
@@ -6,4 +6,10 @@ test_that("db_timestamp produce consistent results", { for (conn in conns) { # n
     db_timestamp(ts_posix, conn),
     db_timestamp(ts_str, conn)
   )
+
+  # Test using NULL conn to trigger
+  expect_identical(
+    db_timestamp.default(ts_posix, conn = NULL),
+    db_timestamp.default(ts_str, conn = NULL)
+  )
 }})

--- a/tests/testthat/test-get_table.R
+++ b/tests/testthat/test-get_table.R
@@ -64,3 +64,9 @@ test_that("get_table() works", { for (conn in conns) { # nolint: brace_linter
   t <- id("tset.mtcars", conn)
   expect_error(get_table(conn, t), regexp = "Table tset.mtcars is not found!")
 }})
+
+test_that("get_table returns list of tables if no table is requested", { for (conn in conns) {
+  expect_output(get_table(conn),
+                regexp = "Select one of the following tables:"
+  )
+}})

--- a/tests/testthat/test-get_table.R
+++ b/tests/testthat/test-get_table.R
@@ -65,8 +65,8 @@ test_that("get_table() works", { for (conn in conns) { # nolint: brace_linter
   expect_error(get_table(conn, t), regexp = "Table tset.mtcars is not found!")
 }})
 
-test_that("get_table returns list of tables if no table is requested", { for (conn in conns) {
+test_that("get_table returns list of tables if no table is requested", { for (conn in conns) { # nolint: brace_linter
   expect_output(get_table(conn),
-                regexp = "Select one of the following tables:"
+    regexp = "Select one of the following tables:"
   )
 }})


### PR DESCRIPTION
With the commits below, test coverage is increased to >85% for each file (~93% for all files combined).

Increased coverage can obviously be reached, as there still exist some lines of code covering more or less impossible (or highly impractical) edge-cases, and there could arguably be some use of `# nocov` statements, as most of them serve as imaginative sanity checks.

One such case is `table_exists()` getting >1 matches for a table despite no wildcard matching. This edge case can potentially be reached by having a schema "one.two" containing a table "three" and schema "one" containing a table "two.three". We already require some implementations (e.g. PostgreSQL) to have an existing schema "test" in order to unlock usability, so I'm personally hesitant about requiring a developer to set up two additional schemas in order to test an edge-case that may not even be possible (I don't know if schema names may contain `.`'s in any dialects).

Therefore, I'm keeping the >1 check in `table_exists()` for now.