### PR TITLE
Increased test coverage for update_snapshot.R and get_table.R

### DIFF
--- a/R/get_table.R
+++ b/R/get_table.R
@@ -102,10 +102,10 @@ get_tables <- function(conn, pattern = NULL) {
       }
 
       # ...retrieve all tables
-      DBI::dbListObjects(conn, .x) |>
+      DBI::dbListObjects(conn, .x) |> # nocov start
         dplyr::pull(table) |>
         purrr::map(\(.y) data.frame(schema = .x@name, table = .y@name["table"])) |>
-        purrr::reduce(rbind.data.frame)
+        purrr::reduce(rbind.data.frame) # nocov end
     }) |>
     purrr::reduce(rbind.data.frame)
 
@@ -113,13 +113,13 @@ get_tables <- function(conn, pattern = NULL) {
   tables <- dplyr::filter(tables, !startsWith(.data$table, "dbplyr_"))
 
   # Skip PostgreSQL metadata tables
-  if (inherits(conn, "PqConnection")) {
+  if (inherits(conn, "PqConnection")) { # nocov start
     tables <- dplyr::filter(tables,
                             dplyr::case_when(is.na(schema) ~ TRUE,
                                              .data$schema == "information_schema" ~ FALSE,
                                              grepl("^pg_.*", .data$schema) ~ FALSE,
                                              TRUE ~ TRUE))
-  }
+  } # nocov end
 
   # Subset if pattern is given
   if (!is.null(pattern)) {

--- a/R/get_table.R
+++ b/R/get_table.R
@@ -102,10 +102,10 @@ get_tables <- function(conn, pattern = NULL) {
       }
 
       # ...retrieve all tables
-      DBI::dbListObjects(conn, .x) |> # nocov start
+      DBI::dbListObjects(conn, .x) |>
         dplyr::pull(table) |>
         purrr::map(\(.y) data.frame(schema = .x@name, table = .y@name["table"])) |>
-        purrr::reduce(rbind.data.frame) # nocov end
+        purrr::reduce(rbind.data.frame)
     }) |>
     purrr::reduce(rbind.data.frame)
 
@@ -113,13 +113,13 @@ get_tables <- function(conn, pattern = NULL) {
   tables <- dplyr::filter(tables, !startsWith(.data$table, "dbplyr_"))
 
   # Skip PostgreSQL metadata tables
-  if (inherits(conn, "PqConnection")) { # nocov start
+  if (inherits(conn, "PqConnection")) {
     tables <- dplyr::filter(tables,
                             dplyr::case_when(is.na(schema) ~ TRUE,
                                              .data$schema == "information_schema" ~ FALSE,
                                              grepl("^pg_.*", .data$schema) ~ FALSE,
                                              TRUE ~ TRUE))
-  } # nocov end
+  }
 
   # Subset if pattern is given
   if (!is.null(pattern)) {

--- a/tests/testthat/test-update_snapshot.R
+++ b/tests/testthat/test-update_snapshot.R
@@ -202,30 +202,34 @@ test_that("update_snapshot checks table formats", {
     timestamp <- Sys.time()
 
     # Test columns not matching
-    broken_table <- copy_to(conn, dplyr::select(mtcars, -"mpg"), name = "mtcars_broken", overwrite = T)
+    broken_table <- copy_to(conn, dplyr::select(mtcars, -"mpg"), name = "mtcars_broken", overwrite = TRUE)
 
-    expect_error(
-      utils::capture.output(update_snapshot(
+    expect_error(utils::capture.output(
+      update_snapshot(
         .data = broken_table,
         conn = conn,
         db_table = mtcars_table,
         timestamp = timestamp,
         message = "Test a broken input table"
       ),
-    regex = "Columns do not match!"))
+      regex = "Columns do not match!"
+    ))
 
-    file.remove(list.files(getOption("SCDB.log_path"), pattern = format(timestamp, "^%Y%m%d.%H%M"), full.names = T))
+    file.remove(list.files(getOption("SCDB.log_path"), pattern = format(timestamp, "^%Y%m%d.%H%M"), full.names = TRUE))
 
     # Test target table not being a historical table
-    expect_error(utils::capture.output(update_snapshot(
-      tbl(conn, id("test.mtcars", conn = conn), mtcars),
-      conn,
-      tbl(conn, "__mtcars"),
-      timestamp = timestamp,
-      message = "Test target table not being historical"
-    ),
-    regex = "Table does not seem like a historical table"
-    ))
+    expect_error(
+      utils::capture.output(
+        update_snapshot(
+          tbl(conn, id("test.mtcars", conn = conn), mtcars),
+          conn,
+          tbl(conn, "__mtcars"),
+          timestamp = timestamp,
+          message = "Test target table not being historical"
+        ),
+        regex = "Table does not seem like a historical table"
+      )
+    )
   }
 
   options(ops)

--- a/tests/testthat/test-update_snapshot.R
+++ b/tests/testthat/test-update_snapshot.R
@@ -209,7 +209,8 @@ test_that("update_snapshot checks table formats", {
         .data = broken_table,
         conn = conn,
         db_table = mtcars_table,
-        timestamp = timestamp
+        timestamp = timestamp,
+        message = "Test a broken input table"
       ),
     regex = "Columns do not match!"))
 
@@ -220,7 +221,8 @@ test_that("update_snapshot checks table formats", {
       tbl(conn, id("test.mtcars", conn = conn), mtcars),
       conn,
       tbl(conn, "__mtcars"),
-      timestamp = timestamp
+      timestamp = timestamp,
+      message = "Test target table not being historical"
     ),
     regex = "Table does not seem like a historical table"
     ))


### PR DESCRIPTION
Added tests for `update_snapshot()`:

* Columns of input and target tables do not match
* Target table does not seem like a historical table
* `message` argument to `update_snapshot()`

~~nocov blocks were also added to get_table.R in order to skip PostgreSQL-specific functions (see also #7)~~ this commit was reverted