### PR TITLE
test: adding test for non-ascii

### DIFF
--- a/tests/testthat/test-non_ascii.R
+++ b/tests/testthat/test-non_ascii.R
@@ -1,0 +1,18 @@
+test_that("Code contains no non-ascii characters", {
+  pkg_dir <- str_remove(getwd(), "/tests/testthat")
+
+  r_files  <- list.files(path = file.path(pkg_dir, "R"),   pattern = r"{\.[Rr]$}",     full.names = TRUE)
+  rd_files <- list.files(path = file.path(pkg_dir, "man"), pattern = r"{\.[Rr][Dd]$}", full.names = TRUE)
+
+  files_to_check <- c(r_files, rd_files) |>
+    purrr::discard(~ stringr::str_detect(.x, "SCDB-package"))
+
+  for (file in files_to_check) {
+    lines <- readLines(file, warn = FALSE)
+    has_non_ascii <- any(grepl(r"{[^\x00-\x7f]}", lines, perl = TRUE))
+    if (has_non_ascii) {
+      print(grepl(r"{[^\x00-\x7f]}", lines, perl = TRUE))
+    }
+    expect_false(has_non_ascii, label = paste("File:", file))
+  }
+})


### PR DESCRIPTION
This PR includes a test for non-ascii characters to the test framework