### PR TITLE
Move warning about no tables to get_tables

### DIFF
--- a/R/connection.R
+++ b/R/connection.R
@@ -74,19 +74,6 @@ get_connection <- function(drv = RPostgres::Postgres(),
                          bigint = "integer", # R has poor integer64 integration, which is the default return
                          check_interrupts = TRUE)
 
-  # Check connection
-  if (nrow(get_tables(conn)) == 0) {
-    warn_str <- "No tables found. Check user permissions / database configuration"
-    args <- c(as.list(environment()), list(...))
-    set_args <- args[names(args) %in% c("dbname", "host", "port", "user", "password")]
-
-    if (length(set_args) > 0) {
-      warn_str <- paste0(warn_str, ":\n  ")
-      warn_str <- paste0(warn_str, paste(names(set_args), set_args, sep = ": ", collapse = "\n  "))
-    }
-    warning(warn_str)
-  }
-
   return(conn)
 }
 

--- a/R/get_table.R
+++ b/R/get_table.R
@@ -93,7 +93,12 @@ get_tables <- function(conn, pattern = NULL) {
     dplyr::select(table)
 
   # purrr::map fails if .x is empty, avoid by returning early
-  if (nrow(objs) == 0) return(data.frame(schema = character(), table = character()))
+  if (nrow(objs) == 0) {
+    if (!(inherits(conn, "SQLiteConnection") & conn@dbname %in% c("", ":memory:"))) {
+      warning("No tables found. Check user permissions / database configuration")
+    }
+    return(data.frame(schema = character(), table = character()))
+  }
 
   tables <- objs$table |> # For each top-level object (except tables)...
     purrr::map(\(.x) {

--- a/R/get_table.R
+++ b/R/get_table.R
@@ -94,7 +94,7 @@ get_tables <- function(conn, pattern = NULL) {
 
   # purrr::map fails if .x is empty, avoid by returning early
   if (nrow(objs) == 0) {
-    if (!(inherits(conn, "SQLiteConnection") & conn@dbname %in% c("", ":memory:"))) {
+    if (!(inherits(conn, "SQLiteConnection") && conn@dbname %in% c("", ":memory:"))) {
       warning("No tables found. Check user permissions / database configuration")
     }
     return(data.frame(schema = character(), table = character()))

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -5,7 +5,7 @@ conn_list <- list(
   "PostgreSQL" = "RPostgres::Postgres"
 )
 
-get_driver <- function(x) {
+get_driver <- function(x = character(), ...) {
   if (!grepl(".*::.*", x)) stop("Package must be specified with namespace (e.g. RSQLite::SQLite)!\n",
                                 "Received: ", x)
   parts <- strsplit(x, "::")[[1]]
@@ -17,7 +17,7 @@ get_driver <- function(x) {
 
   drv <- getExportedValue(parts[1], parts[2])
 
-  tryCatch(suppressWarnings(get_connection(drv = drv())),  # We expect a warning if no tables are found
+  tryCatch(suppressWarnings(get_connection(drv = drv(), ...)),  # We expect a warning if no tables are found
            error = function(e) {
              NULL # Return NULL, if we cannot connect
            })

--- a/tests/testthat/test-get_table.R
+++ b/tests/testthat/test-get_table.R
@@ -83,6 +83,7 @@ testthat::test_that("get_tables skips warning about no tables found in temporary
         get_driver(getElement(conn_list, names(.x)), dbname = temp_db_file)
       })()
 
-    expect_warning(get_tables(conn2))
+    expect_warning(get_tables(conn2),
+                   regex = "No tables found")
   }
 })

--- a/tests/testthat/test-get_table.R
+++ b/tests/testthat/test-get_table.R
@@ -70,3 +70,19 @@ test_that("get_table returns list of tables if no table is requested", { for (co
     regexp = "Select one of the following tables:"
   )
 }})
+
+testthat::test_that("get_tables skips warning about no tables found in temporary databases", {
+  for (conn in conns) {
+    if (!inherits(conn, "SQLiteConnection")) next
+
+    temp_db_file <- tempfile(pattern = "SCDB_test", fileext = ".SQLite")
+
+    # Clone the current connection
+    conn2 <- Filter(\(.x) identical(.x, conn), conns) |>
+      (\(.x) {
+        get_driver(getElement(conn_list, names(.x)), dbname = temp_db_file)
+      })()
+
+    expect_warning(get_tables(conn2))
+  }
+})


### PR DESCRIPTION
Also skips warning about no tables found when connected to a temporary SQLite database (driver inherits from `SQLiteConnection`), both on disk (`dbname = ""`) and memory (`dbname = ":memory:"`).

Additionally, `...` added to get_driver in `tests/testthat/setup.R`, which are passed to `get_connection()`.