### PR TITLE
Add option to suppress Logger output

### DIFF
--- a/R/Logger.R
+++ b/R/Logger.R
@@ -95,18 +95,27 @@ Logger <- R6::R6Class( #nolint: object_name_linter
     #' Write a line to log file
     #' @param ... `r log_dots <- "One or more character strings to be concatenated"; log_dots`
     #' @param tic The timestamp used by the log entry (default Sys.time())
-    #' @param split Should the log line also be printed to console?
+    #' @param output_to_console Should the line be written to console?
     #' @param log_type `r log_type <- "A character string which describes the severity of the log message"; log_type`
-    log_info = function(..., tic = Sys.time(), split = self$output_to_console, log_type = "INFO") {
+    log_info = function(..., tic = Sys.time(), output_to_console = self$output_to_console, log_type = "INFO") {
 
-      # Writes log file (if set)
-      if (!is.null(self$log_path)) {
-        sink(file = file.path(self$log_path, self$log_filename), split = split, append = TRUE, type = "output")
+      format_str <- private$log_format(..., tic = tic, log_type = log_type)
+
+      # Write log file (if set)
+      if (is.null(self$log_path)) {
+        fp <- nullfile()
+      } else {
+        fp <- file.path(self$log_path, self$log_filename)
       }
 
+      sink(
+        file = fp,
+        split = isTRUE(output_to_console),
+        append = TRUE,
+        type = "output"
+      )
       cat(private$log_format(..., tic = tic, log_type = log_type), "\n", sep = "")
-
-      if (!is.null(self$log_path)) sink()
+      sink()
     },
 
     #' @description Write a warning to log file and generate warning.

--- a/R/Logger.R
+++ b/R/Logger.R
@@ -34,7 +34,7 @@ Logger <- R6::R6Class( #nolint: object_name_linter
 
     #' @field output_to_console (`logical(1)`)\cr
     #' Should the Logger output to console?
-    #' This can always be overridden by Logger$log_info(split = FALSE).
+    #' This can always be overridden by Logger$log_info(..., output_to_console = FALSE).
     output_to_console = NULL,
 
     #' @description

--- a/R/Logger.R
+++ b/R/Logger.R
@@ -32,7 +32,7 @@ Logger <- R6::R6Class( #nolint: object_name_linter
     #' The time at which data processing was started.
     start_time = NULL,
 
-    #' @field print_to_console (`logical(1)`)\cr
+    #' @field output_to_console (`logical(1)`)\cr
     #' Should the Logger output to console?
     #' This can always be overridden by Logger$log_info(split = FALSE).
     output_to_console = NULL,
@@ -95,6 +95,7 @@ Logger <- R6::R6Class( #nolint: object_name_linter
     #' Write a line to log file
     #' @param ... `r log_dots <- "One or more character strings to be concatenated"; log_dots`
     #' @param tic The timestamp used by the log entry (default Sys.time())
+    #' @param split Should the log line also be printed to console?
     #' @param log_type `r log_type <- "A character string which describes the severity of the log message"; log_type`
     log_info = function(..., tic = Sys.time(), split = self$output_to_console, log_type = "INFO") {
 

--- a/R/Logger.R
+++ b/R/Logger.R
@@ -32,14 +32,21 @@ Logger <- R6::R6Class( #nolint: object_name_linter
     #' The time at which data processing was started.
     start_time = NULL,
 
+    #' @field print_to_console (`logical(1)`)\cr
+    #' Should the Logger output to console?
+    #' This can always be overridden by Logger$log_info(split = FALSE).
+    output_to_console = NULL,
+
     #' @description
     #' Create a new Logger object
     #' @param log_conn A database connection inheriting from `DBIConnection`
     #' @param warn Show a warning if neither log_table_id or log_path could be determined
+    #' @param output_to_console Should the Logger output to console (TRUE/FALSE)?
     initialize = function(db_tablestring = NULL,
                           log_table_id   = getOption("SCDB.log_table_id"),
                           log_conn = NULL,
                           log_path = getOption("SCDB.log_path"),
+                          output_to_console = TRUE,
                           warn = TRUE,
                           ts = NULL,
                           start_time = Sys.time()) {
@@ -53,6 +60,8 @@ Logger <- R6::R6Class( #nolint: object_name_linter
       assert_timestamp_like(ts, add = coll)
       checkmate::assert_posixct(start_time, add = coll)
       checkmate::reportAssertions(coll)
+
+      self$output_to_console <- output_to_console
 
       private$ts <- ts
       self$start_time <- start_time
@@ -87,11 +96,11 @@ Logger <- R6::R6Class( #nolint: object_name_linter
     #' @param ... `r log_dots <- "One or more character strings to be concatenated"; log_dots`
     #' @param tic The timestamp used by the log entry (default Sys.time())
     #' @param log_type `r log_type <- "A character string which describes the severity of the log message"; log_type`
-    log_info = function(..., tic = Sys.time(), log_type = "INFO") {
+    log_info = function(..., tic = Sys.time(), split = self$output_to_console, log_type = "INFO") {
 
       # Writes log file (if set)
       if (!is.null(self$log_path)) {
-        sink(file = file.path(self$log_path, self$log_filename), split = TRUE, append = TRUE, type = "output")
+        sink(file = file.path(self$log_path, self$log_filename), split = split, append = TRUE, type = "output")
       }
 
       cat(private$log_format(..., tic = tic, log_type = log_type), "\n", sep = "")

--- a/man/Logger.Rd
+++ b/man/Logger.Rd
@@ -94,7 +94,7 @@ Write a line to log file
 \if{html}{\out{<div class="r">}}\preformatted{Logger$log_info(
   ...,
   tic = Sys.time(),
-  split = self$output_to_console,
+  output_to_console = self$output_to_console,
   log_type = "INFO"
 )}\if{html}{\out{</div>}}
 }
@@ -106,7 +106,7 @@ Write a line to log file
 
 \item{\code{tic}}{The timestamp used by the log entry (default Sys.time())}
 
-\item{\code{split}}{Should the log line also be printed to console?}
+\item{\code{output_to_console}}{Should the line be written to console?}
 
 \item{\code{log_type}}{A character string which describes the severity of the log message}
 }

--- a/man/Logger.Rd
+++ b/man/Logger.Rd
@@ -29,7 +29,7 @@ The time at which data processing was started.}
 
 \item{\code{output_to_console}}{(\code{logical(1)})\cr
 Should the Logger output to console?
-This can always be overridden by Logger$log_info(split = FALSE).}
+This can always be overridden by Logger$log_info(..., output_to_console = FALSE).}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/Logger.Rd
+++ b/man/Logger.Rd
@@ -26,6 +26,10 @@ The name (basename) of the log file.}
 
 \item{\code{start_time}}{(\code{POSIXct(1)})\cr
 The time at which data processing was started.}
+
+\item{\code{output_to_console}}{(\code{logical(1)})\cr
+Should the Logger output to console?
+This can always be overridden by Logger$log_info(split = FALSE).}
 }
 \if{html}{\out{</div>}}
 }
@@ -51,6 +55,7 @@ Create a new Logger object
   log_table_id = getOption("SCDB.log_table_id"),
   log_conn = NULL,
   log_path = getOption("SCDB.log_path"),
+  output_to_console = TRUE,
   warn = TRUE,
   ts = NULL,
   start_time = Sys.time()
@@ -69,6 +74,8 @@ Create a new Logger object
 \item{\code{log_path}}{The path where logs are stored.
 If NULL, no file logs are created.}
 
+\item{\code{output_to_console}}{Should the Logger output to console (TRUE/FALSE)?}
+
 \item{\code{warn}}{Show a warning if neither log_table_id or log_path could be determined}
 
 \item{\code{ts}}{A timestamp describing the data being processed (not the current time)}
@@ -84,7 +91,12 @@ If NULL, no file logs are created.}
 \subsection{Method \code{log_info()}}{
 Write a line to log file
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Logger$log_info(..., tic = Sys.time(), log_type = "INFO")}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Logger$log_info(
+  ...,
+  tic = Sys.time(),
+  split = self$output_to_console,
+  log_type = "INFO"
+)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -93,6 +105,8 @@ Write a line to log file
 \item{\code{...}}{One or more character strings to be concatenated}
 
 \item{\code{tic}}{The timestamp used by the log entry (default Sys.time())}
+
+\item{\code{split}}{Should the log line also be printed to console?}
 
 \item{\code{log_type}}{A character string which describes the severity of the log message}
 }

--- a/tests/testthat/test-Logger.R
+++ b/tests/testthat/test-Logger.R
@@ -146,3 +146,44 @@ test_that("Logger stops if file exists", { for (conn in conns) { # nolint: brace
 
   file.remove(file.path(log_path, logger$log_filename))
 }})
+
+test_that("Logger console output may be suppressed", {
+  db_tablestring <- "test.SCDB_logger"
+  ts <- Sys.time()
+  log_path <- tempdir()
+
+  # Test output_to_console == FALSE by default
+  logger <- Logger$new(
+    db_tablestring = db_tablestring,
+    ts = ts,
+    log_table_id = NULL,
+    log_path = log_path,
+    output_to_console = FALSE
+  )
+
+  expect_identical(
+    utils::capture.output(logger$log_info("Whoops! This should not have been printed!"), type = "output"),
+    character(0)
+  )
+  expect_identical(
+    utils::capture.output(logger$log_info("Whoops! This should not have been printed either!", split = FALSE), type = "output"),
+    character(0)
+  )
+
+  expect_output(
+    logger$log_info("This line should be printed", split = TRUE),
+    regex = "This line should be printed$"
+  )
+
+  logger$output_to_console <- TRUE
+
+  expect_output(
+    logger$log_info("This line should be printed"),
+    regex = "This line should be printed$"
+  )
+
+  expect_identical(
+    utils::capture.output(logger$log_info("Whoops! This should not have been printed at all!", split = FALSE), type = "output"),
+    character(0)
+  )
+})

--- a/tests/testthat/test-Logger.R
+++ b/tests/testthat/test-Logger.R
@@ -166,7 +166,8 @@ test_that("Logger console output may be suppressed", {
     character(0)
   )
   expect_identical(
-    utils::capture.output(logger$log_info("Whoops! This should not have been printed either!", split = FALSE), type = "output"),
+    utils::capture.output(logger$log_info("Whoops! This should not have been printed either!", split = FALSE),
+                          type = "output"),
     character(0)
   )
 
@@ -183,7 +184,8 @@ test_that("Logger console output may be suppressed", {
   )
 
   expect_identical(
-    utils::capture.output(logger$log_info("Whoops! This should not have been printed at all!", split = FALSE), type = "output"),
+    utils::capture.output(logger$log_info("Whoops! This should not have been printed at all!", split = FALSE),
+                          type = "output"),
     character(0)
   )
 })

--- a/tests/testthat/test-Logger.R
+++ b/tests/testthat/test-Logger.R
@@ -152,7 +152,8 @@ test_that("Logger console output may be suppressed", {
   ts <- Sys.time()
   log_path <- tempdir()
 
-  # Test output_to_console == FALSE by default
+  # First test cases with output_to_console == FALSE
+  # Here, only print when explicitly stated
   logger <- Logger$new(
     db_tablestring = db_tablestring,
     ts = ts,
@@ -161,30 +162,40 @@ test_that("Logger console output may be suppressed", {
     output_to_console = FALSE
   )
 
+  # In lieu of testthat::expect_no_output...
   expect_identical(
     utils::capture.output(logger$log_info("Whoops! This should not have been printed!"), type = "output"),
     character(0)
   )
   expect_identical(
-    utils::capture.output(logger$log_info("Whoops! This should not have been printed either!", split = FALSE),
+    utils::capture.output(logger$log_info("Whoops! This should not have been printed either!",
+                                          output_to_console = FALSE),
                           type = "output"),
     character(0)
   )
 
   expect_output(
-    logger$log_info("This line should be printed", split = TRUE),
+    logger$log_info("This line should be printed",
+                    output_to_console = TRUE),
     regex = "This line should be printed$"
   )
 
+  # ...and now, only suppress printing when explicitly stated
   logger$output_to_console <- TRUE
 
   expect_output(
     logger$log_info("This line should be printed"),
     regex = "This line should be printed$"
   )
+  expect_output(
+    logger$log_info("This line should also be printed",
+                    output_to_console = TRUE),
+    regex = "This line should also be printed$"
+  )
 
   expect_identical(
-    utils::capture.output(logger$log_info("Whoops! This should not have been printed at all!", split = FALSE),
+    utils::capture.output(logger$log_info("Whoops! This should not have been printed at all!",
+                                          output_to_console = FALSE),
                           type = "output"),
     character(0)
   )


### PR DESCRIPTION
Fixes #18.

A `Logger` object may now be initialized with an argument `output_to_console`, determining if output by default should be printed to console.

This behavior is easily overridden by passing `TRUE` or `FALSE` to `Logger$log_info(split)`.

This allows for simultaneous resolution of #17 and #16 in that `update_snapshot` may be updated to take a predefined `Logger` object (which may or may not have console output suppressed).