### PR TITLE
Enable initialising Logger with no arguments

### DIFF
--- a/R/Logger.R
+++ b/R/Logger.R
@@ -136,6 +136,7 @@ Logger <- R6::R6Class( #nolint: object_name_linter
 
   private = list(
 
+    .log_filename = NULL,
     db_tablestring = NULL,
     log_conn = NULL,
     ts = NULL,
@@ -162,7 +163,11 @@ Logger <- R6::R6Class( #nolint: object_name_linter
   active = list(
     log_filename = function() {
       # If we are not producing a file log, we provide a random string to key by
-      if (is.null(self$log_path)) return(basename(tempfile(tmpdir = "", pattern = "")))
+      if (!is.null(private$.log_filename)) return(private$.log_filename)
+      if (is.null(self$log_path)) {
+        private$.log_filename <- basename(tempfile(tmpdir = "", pattern = ""))
+        return(private$.log_filename)
+      }
 
       coll <- checkmate::makeAssertCollection()
       checkmate::assert_character(private$db_tablestring, null.ok = FALSE, add = coll)
@@ -181,7 +186,13 @@ Logger <- R6::R6Class( #nolint: object_name_linter
         private$db_tablestring
       )
 
-      filename
+      private$.log_filename <- filename
+
+      if (file.exists(file.path(self$log_path, private$.log_filename))) {
+        stop(sprintf("Log file '%s' already exists!", private$.log_filename))
+      }
+
+      return(filename)
     },
 
     log_realpath = function() {

--- a/R/Logger.R
+++ b/R/Logger.R
@@ -161,6 +161,8 @@ Logger <- R6::R6Class( #nolint: object_name_linter
   ),
 
   active = list(
+    #' @field log_filename `character(1)`\cr
+    #' The filename (basename) of the file that the `Logger` instance will output to
     log_filename = function() {
       # If we are not producing a file log, we provide a random string to key by
       if (!is.null(private$.log_filename)) return(private$.log_filename)
@@ -195,6 +197,8 @@ Logger <- R6::R6Class( #nolint: object_name_linter
       return(filename)
     },
 
+    #' @field log_realpath `character(1)`\cr
+    #' The full path to the logger's log file.
     log_realpath = function() {
       if (is.null(self$log_path)) {
         nullfile()

--- a/R/update_snapshot.R
+++ b/R/update_snapshot.R
@@ -10,8 +10,8 @@
 #' @param tic
 #'   A timestamp when computation began. If not supplied, it will be created at call-time.
 #'   (Used to more accurately convey how long runtime of the update process has been)
-#' @template log_path
-#' @template log_table_id
+#' @param logger
+#'   A [Logger]. If none is given, one is initialized with default arguments.
 #' @param enforce_chronological_order
 #'   A logical that controls whether or not to check if timestamp of update is prior to timestamps in the DB
 #' @return No return value, called for side effects
@@ -30,7 +30,7 @@
 #' @importFrom rlang .data
 #' @export
 update_snapshot <- function(.data, conn, db_table, timestamp, filters = NULL, message = NULL, tic = Sys.time(), # nolint: cyclocomp_linter
-                            log_path = getOption("SCDB.log_path"), log_table_id = getOption("SCDB.log_table_id"),
+                            logger = NULL,
                             enforce_chronological_order = TRUE) {
 
   # Check arguments
@@ -41,6 +41,7 @@ update_snapshot <- function(.data, conn, db_table, timestamp, filters = NULL, me
   checkmate::assert_class(filters, "tbl_dbi", null.ok = TRUE)
   checkmate::assert_character(message, null.ok = TRUE)
   assert_timestamp_like(tic)
+  checkmate::assert_class(logger, "Logger", null.ok = TRUE)
   checkmate::assert_logical(enforce_chronological_order)
 
 
@@ -62,14 +63,14 @@ update_snapshot <- function(.data, conn, db_table, timestamp, filters = NULL, me
   }
 
   # Initialize logger
-  logger <- Logger$new(
-    db_tablestring = db_table_name,
-    log_table_id = log_table_id,
-    log_conn = conn,
-    log_path = log_path,
-    ts = timestamp,
-    start_time = tic
-  )
+  if (is.null(logger)) {
+    logger <- Logger$new(
+      db_tablestring = db_table_name,
+      log_conn = conn,
+      ts = timestamp,
+      start_time = tic
+    )
+  }
 
   logger$log_to_db(start_time = !!db_timestamp(tic, conn))
   logger$log_info("Started", tic = tic) # Use input time in log

--- a/R/update_snapshot.R
+++ b/R/update_snapshot.R
@@ -11,7 +11,7 @@
 #'   A timestamp when computation began. If not supplied, it will be created at call-time.
 #'   (Used to more accurately convey how long runtime of the update process has been)
 #' @param logger
-#'   A [Logger]. If none is given, one is initialized with default arguments.
+#'   A [Logger] instance. If none is given, one is initialized with default arguments.
 #' @param enforce_chronological_order
 #'   A logical that controls whether or not to check if timestamp of update is prior to timestamps in the DB
 #' @return No return value, called for side effects

--- a/man/Logger.Rd
+++ b/man/Logger.Rd
@@ -30,6 +30,17 @@ This can always be overridden by Logger$log_info(..., output_to_console = FALSE)
 }
 \if{html}{\out{</div>}}
 }
+\section{Active bindings}{
+\if{html}{\out{<div class="r6-active-bindings">}}
+\describe{
+\item{\code{log_filename}}{\code{character(1)}\cr
+The filename (basename) of the file that the \code{Logger} instance will output to}
+
+\item{\code{log_realpath}}{\code{character(1)}\cr
+The full path to the logger's log file.}
+}
+\if{html}{\out{</div>}}
+}
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{

--- a/man/Logger.Rd
+++ b/man/Logger.Rd
@@ -19,9 +19,6 @@ logger <- Logger$new(db_tablestring = "test.table",
 \item{\code{log_path}}{(\code{character(1)})\cr
 A directory where log file is written (if this is not NULL). Defaults to \code{getOption("SCDB.log_path")}.}
 
-\item{\code{log_filename}}{(\code{character(1)})\cr
-The name (basename) of the log file.}
-
 \item{\code{log_tbl}}{The DB table used for logging. Class is connection-specific, but inherits from \code{tbl_dbi}.}
 
 \item{\code{start_time}}{(\code{POSIXct(1)})\cr

--- a/man/update_snapshot.Rd
+++ b/man/update_snapshot.Rd
@@ -12,8 +12,7 @@ update_snapshot(
   filters = NULL,
   message = NULL,
   tic = Sys.time(),
-  log_path = getOption("SCDB.log_path"),
-  log_table_id = getOption("SCDB.log_table_id"),
+  logger = NULL,
   enforce_chronological_order = TRUE
 )
 }
@@ -33,10 +32,7 @@ update_snapshot(
 \item{tic}{A timestamp when computation began. If not supplied, it will be created at call-time.
 (Used to more accurately convey how long runtime of the update process has been)}
 
-\item{log_path}{The path where logs are stored.
-If NULL, no file logs are created.}
-
-\item{log_table_id}{A \code{\link[DBI:Id]{DBI::Id()}} object or a character string readable by \link{id}, specifying the location of the log table.}
+\item{logger}{A \link{Logger}. If none is given, one is initialized with default arguments.}
 
 \item{enforce_chronological_order}{A logical that controls whether or not to check if timestamp of update is prior to timestamps in the DB}
 }

--- a/man/update_snapshot.Rd
+++ b/man/update_snapshot.Rd
@@ -32,7 +32,7 @@ update_snapshot(
 \item{tic}{A timestamp when computation began. If not supplied, it will be created at call-time.
 (Used to more accurately convey how long runtime of the update process has been)}
 
-\item{logger}{A \link{Logger}. If none is given, one is initialized with default arguments.}
+\item{logger}{A \link{Logger} instance. If none is given, one is initialized with default arguments.}
 
 \item{enforce_chronological_order}{A logical that controls whether or not to check if timestamp of update is prior to timestamps in the DB}
 }

--- a/tests/testthat/test-Logger.R
+++ b/tests/testthat/test-Logger.R
@@ -4,15 +4,9 @@ test_that("Logger works", { for (conn in conns) { # nolint: brace_linter
   db_tablestring <- "test.SCDB_logger"
   ts <- "2022-01-01 09:00:00"
 
-  # Logger cannot work without these set
-  expect_error(Logger$new(), regexp = "'db_tablestring': Must be of type 'character'")
-  expect_error(Logger$new(ts = ts), regexp = "'db_tablestring': Must be of type 'character'")
-  expect_error(Logger$new(db_tablestring = db_tablestring), regexp = "not 'NULL'")
-
-
   # minimal logger
   expect_warning(
-    logger <- Logger$new(db_tablestring = db_tablestring, ts = ts, log_table_id = NULL, log_path = NULL),
+    logger <- Logger$new(log_table_id = NULL, log_path = NULL),
     regexp = "NO LOGGING WILL BE DONE"
   )
   expect_null(logger$log_path)
@@ -74,7 +68,6 @@ test_that("Logger works", { for (conn in conns) { # nolint: brace_linter
                        log_conn = conn,
                        warn = FALSE)
   log_table_id <- dplyr::tbl(conn, id("test.SCDB_logs", conn))
-  expect_null(logger$log_path)
   expect_equal(logger$log_tbl, log_table_id)
   logger$log_to_db(n_insertions = 42)
   expect_equal(nrow(log_table_id), 1)
@@ -134,14 +127,16 @@ test_that("Logger stops if file exists", { for (conn in conns) { # nolint: brace
 
   utils::capture.output(logger$log_info("test message"))
 
+  logger2 <- Logger$new(
+    db_tablestring = db_tablestring,
+    ts = ts,
+    start_time = ts,
+    log_table_id = NULL,
+    log_path = log_path
+  )
+
   expect_error(
-    logger2 <- Logger$new(
-      db_tablestring = db_tablestring,
-      ts = ts,
-      start_time = ts,
-      log_table_id = NULL,
-      log_path = log_path
-    )
+    logger2$log_info("test message")
   )
 
   file.remove(file.path(log_path, logger$log_filename))


### PR DESCRIPTION
`Logger$generate_filename()` has been changed to an active binding `Logger$log_filename`

With these changes, the `Logger` will not require `db_tablestring` and `ts` to be set until `Logger$log_filename` is called, and only when attempting to write an actual file (closes #17).

Instead of taking arguments `log_table_id` and/or `log_path` (or neither), `update_snapshot` now may take an already initialized `Logger` object with the `logger` argument, allowing for better control of console output (closes #16).