### PR TITLE
Warn user when connecting with a backend not fully supported

### DIFF
--- a/R/connection.R
+++ b/R/connection.R
@@ -49,6 +49,15 @@ get_connection <- function(drv = RPostgres::Postgres(),
   checkmate::assert_character(timezone, null.ok = TRUE)
   checkmate::assert_character(timezone_out, null.ok = TRUE)
 
+  supported_drivers <- c(
+    "PqDriver",
+    "SQLiteDriver"
+  )
+
+  if (!class(drv) %in% supported_drivers) {
+    warning("Driver of class'", class(drv), "' is currently not fully supported and SCDB may not perform as expected.")
+  }
+
   # Set PostgreSQL-specific options
   if (inherits(drv, "PqDriver")) {
     if (is.null(timezone)) timezone <- Sys.timezone()

--- a/R/connection.R
+++ b/R/connection.R
@@ -23,11 +23,14 @@
 #'  Additional parameters sent to DBI::dbConnect()
 #' @return
 #'   An object that inherits from DBIConnection driver specified in drv
-#' @examples
-#' \dontrun{
-#' close_connection(conn)
-#' }
+#' @examplesIf requireNamespace("RSQLite", quietly = TRUE)
+#' conn <- get_connection(drv = RSQLite::SQLite(), dbname = ":memory:")
 #'
+#' DBI::dbIsValid(conn) # TRUE
+#'
+#' close_connection(conn)
+#'
+#' DBI::dbIsValid(conn) # FALSE
 #' @seealso [RPostgres::Postgres]
 #' @export
 get_connection <- function(drv = RPostgres::Postgres(),

--- a/man/get_connection.Rd
+++ b/man/get_connection.Rd
@@ -43,10 +43,15 @@ Connects to the specified dbname of host:port using user and password from given
 Certain drivers may use credentials stored in a file, such as ~/.pgpass (PostgreSQL)
 }
 \examples{
-\dontrun{
-close_connection(conn)
-}
+\dontshow{if (requireNamespace("RSQLite", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+conn <- get_connection(drv = RSQLite::SQLite(), dbname = ":memory:")
 
+DBI::dbIsValid(conn) # TRUE
+
+close_connection(conn)
+
+DBI::dbIsValid(conn) # FALSE
+\dontshow{\}) # examplesIf}
 }
 \seealso{
 \link[RPostgres:Postgres]{RPostgres::Postgres}


### PR DESCRIPTION
Close #15.

Also improved documentation example of `get_connection()` using `RSQLite` if available,[^1] actually calling `get_connection()`.

[^1]: `RSQLite` is a dependency on "Suggest" level and is therefore recommended to install for contributors. However, as it is not required for the package to run, CRAN **may occasionally** test the package without RSQLite installed.

