### PR TITLE
Add postgres service to test-coverage

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -11,6 +11,18 @@ name: test-coverage
 jobs:
   test-coverage:
     runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:latest
+        env:
+          POSTGRES_DB: SCDB_test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: --health-cmd "pg_isready -U postgres" --health-interval 10s --health-timeout 5s --health-retries 5
+
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
@@ -25,6 +37,13 @@ jobs:
         with:
           extra-packages: any::covr
           needs: coverage
+
+      - name: Create schema "test" in PostgreSQL
+        run: |
+          psql -h localhost -d SCDB_test -c "CREATE SCHEMA test;"
+        env:
+          PGUSER: postgres
+          PGPASSWORD: postgres
 
       - name: Test coverage
         run: |


### PR DESCRIPTION
This fixes #7.

The test-coverage action is expanded to include a postgres service with a database "SCDB_test" containing a schema "test", which enables for testing PostgreSQL specific functions.