### PR TITLE
Detect schema without tables in schema_exists

### DIFF
--- a/R/get_schema.R
+++ b/R/get_schema.R
@@ -57,7 +57,7 @@ schema_exists <- function(conn, schema) {
   checkmate::assert_class(conn, "DBIConnection")
   checkmate::assert_character(schema)
 
-  if (inherits(conn, "SQLiteConnection")) return(NULL)
+  if (inherits(conn, "SQLiteConnection")) return(FALSE)
 
   objs <- DBI::dbListObjects(conn)
   matches <- sapply(objs$table, \(.x) methods::slot(.x, "name")) |>

--- a/R/get_schema.R
+++ b/R/get_schema.R
@@ -68,12 +68,12 @@ schema_exists <- function(conn, schema) {
   tryCatch({
     DBI::dbCreateTable(
       conn,
-      name = DBI::Id(schema = schema, table = "schema_test"),
+      name = DBI::Id(schema = schema, table = "SCDB_schema_test"),
       fields = data.frame(name = character()),
       temporary = FALSE
     )
 
-    DBI::dbRemoveTable(conn, DBI::Id(schema = schema, table = "schema_test"))
+    DBI::dbRemoveTable(conn, DBI::Id(schema = schema, table = "SCDB_schema_test"))
     TRUE
   },
   error = function(e) FALSE)

--- a/R/get_schema.R
+++ b/R/get_schema.R
@@ -76,6 +76,5 @@ schema_exists <- function(conn, schema) {
     DBI::dbRemoveTable(conn, DBI::Id(schema = schema, table = "schema_test"))
     TRUE
   },
-  error = function(e)
-    FALSE)
+  error = function(e) FALSE)
 }


### PR DESCRIPTION
Turns out one of the issues I had regarding setting up GitHub actions was that `schema_exists` would always return `FALSE` unless a table existed in the schema.

This is now fixed by trying to create a table (and immediately deleting it) if no tables were found within the schema. This does mean that the function will always return `FALSE` on a schema with no tables if the user does not have `CREATE TABLE` privileges.

A more hands-off, backend-specific (i.e. PostgreSQL-specific) solution could be made, but I opted for a potentially wider usable method.