### PR TITLE
Fix Postgres tests failing unexpectedly

### DIFF
--- a/tests/testthat/test-get_table.R
+++ b/tests/testthat/test-get_table.R
@@ -85,5 +85,7 @@ testthat::test_that("get_tables skips warning about no tables found in temporary
 
     expect_warning(get_tables(conn2),
                    regex = "No tables found")
+
+    DBI::dbDisconnect(conn2)
   }
 })

--- a/tests/testthat/test-update_snapshot.R
+++ b/tests/testthat/test-update_snapshot.R
@@ -199,6 +199,8 @@ test_that("update_snapshot() works", { for (conn in conns) { # nolint: brace_lin
                    t_ref |>
                      dplyr::arrange(col1, from_ts))
 
+  if (file.exists(logger$log_realpath)) file.remove(logger$log_realpath)
+
   if (DBI::dbExistsTable(conn, id("test.SCDB_tmp1", conn))) DBI::dbRemoveTable(conn, id("test.SCDB_tmp1", conn))
 }})
 


### PR DESCRIPTION
This resolves #33. It took three iterations to get here:

Initially, the error was caused by a calling `id(...` within `dplyr::copy_to`. Here, namespaces got resolved a little funky[^1], retrieving `dplyr::id`. Specifying `SCDB::id` as of fcb28d9fdf35c7ebe9edbaa305bd0709f9ac92cd resolved this issue. Since the function call did not get resolved as expected, at least one of the tables created in `tests/testthat/setup.R` was not created, causing a lot of failing tests.

After resolving this, an error now occurred in `test-update_snapshot.R` where a previous Logger instance did not clean up after itself, causing the following loop iteration to fail (unless they happened to be initialized in different minutes in time). Furthermore, `test-db_joins.R` failed (a join on **_fewer_** columns took **_more_** time), but resolving the log files mentioned above also made this test pass again.

Additionally, `test-get_table.R` created a connection object, `conn2` which was not closed properly, giving a warning message in test output. 5f6454a0906f47a0f5794593a0d9f10bbf7f3d3a fixes this.

[^1]: "funky" because `dplyr::id` was defunct as of v0.5.0, released a little above 7 years ago.