### PR TITLE
Increase test coverage

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -45,9 +45,9 @@ jobs:
           extra-packages: any::covr
           needs: coverage
 
-      - name: Create schema "test" in PostgreSQL
+      - name: Setup testing schemata in PostgreSQL
         run: |
-          psql SCDB_test -c "CREATE SCHEMA test;"
+          psql SCDB_test -c "CREATE SCHEMA test; CREATE SCHEMA \"test.one\";"
 
       - name: Test coverage
         run: |

--- a/R/connection.R
+++ b/R/connection.R
@@ -58,7 +58,7 @@ get_connection <- function(drv = RPostgres::Postgres(),
   )
 
   if (!class(drv) %in% supported_drivers) {
-    warning("Driver of class'", class(drv), "' is currently not fully supported and SCDB may not perform as expected.")
+    warning("Driver of class '", class(drv), "' is currently not fully supported and SCDB may not perform as expected.")
   }
 
   # Set PostgreSQL-specific options

--- a/R/create_table.R
+++ b/R/create_table.R
@@ -15,7 +15,7 @@
 #'
 #' close_connection(conn)
 #' @export
-create_table <- function(.data, conn = NULL, db_table_id = NULL, temporary = TRUE, ...) {
+create_table <- function(.data, conn = NULL, db_table_id, temporary = TRUE, ...) {
 
   checkmate::assert_class(.data, "data.frame")
   checkmate::assert_class(conn, "DBIConnection", null.ok = TRUE)
@@ -25,11 +25,7 @@ create_table <- function(.data, conn = NULL, db_table_id = NULL, temporary = TRU
   checkmate::assert_character(names(.data), unique = TRUE)
 
   # Convert db_table_id to id (id() returns early if this is the case)
-  if (!is.null(db_table_id)) { # TODO: db_table_name vs db_table_id
-    db_table_id <- id(db_table_id, conn = conn)
-  } else {
-    db_table_id <- deparse(substitute(.data))
-  }
+  db_table_id <- id(db_table_id, conn = conn)
 
   if (is.historical(.data)) {
     stop("checksum/from_ts/until_ts column(s) already exist(s) in .data!")

--- a/R/get_table.R
+++ b/R/get_table.R
@@ -210,6 +210,6 @@ table_exists <- function(conn, db_table_id) {
     dplyr::filter(db_table_id == !!db_table_id) |>
     nrow()
 
-  if (n_matches >= 2) stop("Edge case detected. Cannot determine if table exists!")
+  if (n_matches > 1) stop("More than one table matching '", db_table_id, "' was found!")
   return(n_matches == 1)
 }

--- a/man/create_table.Rd
+++ b/man/create_table.Rd
@@ -4,7 +4,7 @@
 \alias{create_table}
 \title{Create a historical table from input data}
 \usage{
-create_table(.data, conn = NULL, db_table_id = NULL, temporary = TRUE, ...)
+create_table(.data, conn = NULL, db_table_id, temporary = TRUE, ...)
 }
 \arguments{
 \item{.data}{A data frame, a tibble, a data.table or a tbl.}

--- a/tests/testthat/test-connection.R
+++ b/tests/testthat/test-connection.R
@@ -2,6 +2,17 @@ test_that("get_connection() works", {
   for (conn in conns) expect_true(DBI::dbIsValid(conn))
 })
 
+test_that("get_connection notifies if connection fails", {
+  for (i in 1:100) {
+    random_string <- paste(sample(letters, size = 32, replace = TRUE), collapse = "")
+
+    if (dir.exists(random_string)) next
+
+    expect_error(get_connection(drv = RSQLite::SQLite(), dbname = paste0(random_string, "/invalid_path")),
+                 regexp = "Could not connect to database")
+  }
+})
+
 
 test_that("id() works", { for (conn in conns) { # nolint: brace_linter
 

--- a/tests/testthat/test-connection.R
+++ b/tests/testthat/test-connection.R
@@ -13,6 +13,13 @@ test_that("get_connection notifies if connection fails", {
   }
 })
 
+test_that("get_connection warns about unsupported backend", {
+  get_connection(drv = character(0)) |>
+    expect_error(regex = paste("unable to find an inherited method for function",
+                               "'dbCanConnect' for signature '\"character\"'")) |>
+    expect_warning("Driver of class 'character' is currently not fully supported")
+})
+
 
 test_that("id() works", { for (conn in conns) { # nolint: brace_linter
 

--- a/tests/testthat/test-create_table.R
+++ b/tests/testthat/test-create_table.R
@@ -1,0 +1,20 @@
+test_that("create_table refuses a historical table", {
+  mtcars |>
+    dplyr::mutate(from_ts = NA) |>
+    SCDB::create_table(db_table_id = "fail.mtcars") |>
+    expect_error()
+})
+
+test_that("create_table works with no conn", {
+  mylocaltable <- SCDB::create_table(mtcars, db_table_id = "test.mylocaltable", conn = NULL)
+
+  expect_identical(colnames(mylocaltable), c(colnames(mtcars), "checksum", "from_ts", "until_ts"))
+  expect_identical(dplyr::select(mylocaltable, -tidyselect::all_of(c("checksum", "from_ts", "until_ts"))), mtcars)
+})
+
+test_that("getTableSignature generates a signature for NULL connections", {
+  expect_identical(
+    lapply(mtcars, class),
+    as.list(SCDB:::getTableSignature(mtcars, conn = NULL))
+  )
+})


### PR DESCRIPTION
Added some additional tests:

* `get_connection` notifying if connection fails (funnily enough, coverage stopped when we actually configured Postgres correctly)
* `get_connection` warning when using an unsupported driver
* `create_table` refusing a table with checksum, from_ts and until_ts columns
* `create_table` works without connection (returning .data)
* `getTableSignature` generates a signature even for NULL connections
* failing if >1 match found in `table_exists`

Additionally, an impossible condition was removed in `create_table`, and the case of >1 match in `table_exists` also printing the `db_table_id` given.

Also, instead of testing if `SCDB::left_join` with additional columns is strictly faster than `dplyr::left_join`, tolerate the two taking equally long, as this would occasionally cause tests to fail.