### PR TITLE
Increase test coverage

### DIFF
--- a/tests/testthat/test-connection.R
+++ b/tests/testthat/test-connection.R
@@ -9,7 +9,7 @@ test_that("get_connection notifies if connection fails", {
     if (dir.exists(random_string)) next
 
     expect_error(get_connection(drv = RSQLite::SQLite(), dbname = paste0(random_string, "/invalid_path")),
-                 regexp = "Could not connect to database")
+                 regexp = "Could not connect to database:\nunable to open database file")
   }
 })
 

--- a/tests/testthat/test-db_manipulating_functions.R
+++ b/tests/testthat/test-db_manipulating_functions.R
@@ -86,6 +86,10 @@ test_that("interlace_sql() works", { for (conn in conns) { # nolint: brace_linte
 
 }})
 
+test_that("interlace_sql returns early if length(table) == 1", {
+  expect_identical(mtcars$mpg, interlace_sql(mtcars["mpg"], by = "mpg"))
+})
+
 
 test_that("digest_to_checksum() works", { for (conn in conns) { # nolint: brace_linter
 


### PR DESCRIPTION
* Correctly catch dbCanConnect failing
  - Turns out that some errors would cause `DBI::dbCanConnect` to throw an error instead of simply returning `FALSE`. Handling this `tryCatch` allows to more carefully handle these cases
  - `rlang::abort` is used in favor of `base::stop` as the former provides better compatibility with e.g. tracebacks
  - Additionally, `DBI::dbCanConnect` was previously only called with `drv` and `...` arguments, not correctly handling non-default values to named arguments.

* Added a test for interlace_sql with `length` 1.
  - It seems like a slight oversight that this case is no more complex than calling interlace_sql on a table with a single column. Please let me know if there is a deeper meaning to this case not being tested yet.