### PR TITLE
Build README with Rmarkdown

### DIFF
--- a/.github/workflows/render-readme.yaml
+++ b/.github/workflows/render-readme.yaml
@@ -1,0 +1,23 @@
+on:
+  push:
+    paths:
+      - README.md
+
+name: Render README
+
+jobs:
+  render:
+    name: Render README
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: r-lib/actions/setup-r@v2
+      - uses: r-lib/actions/setup-pandoc@v2
+      - name: Install rmarkdown
+        run: Rscript -e 'install.packages("rmarkdown")'
+      - name: Render README
+        run: Rscript -e 'rmarkdown::render("README.Rmd")'
+      - name: Commit results
+        run: |
+          git commit README.md -m 'Re-build README.Rmd' || echo "No changes to commit"
+          git push origin || echo "No changes to commit"

--- a/.github/workflows/render-readme.yaml
+++ b/.github/workflows/render-readme.yaml
@@ -2,6 +2,7 @@ on:
   push:
     paths:
       - README.md
+      - README.Rmd
 
 name: Render README
 

--- a/.github/workflows/render-readme.yaml
+++ b/.github/workflows/render-readme.yaml
@@ -20,5 +20,7 @@ jobs:
         run: Rscript -e 'rmarkdown::render("README.Rmd")'
       - name: Commit results
         run: |
+          git config --local user.name "$GITHUB_ACTOR"
+          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
           git commit README.md -m 'Re-build README.Rmd' || echo "No changes to commit"
           git push origin || echo "No changes to commit"

--- a/.github/workflows/render-readme.yaml
+++ b/.github/workflows/render-readme.yaml
@@ -10,7 +10,7 @@ jobs:
     name: Render README
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: r-lib/actions/setup-r@v2
       - uses: r-lib/actions/setup-pandoc@v2
       - name: Install rmarkdown

--- a/README.Rmd
+++ b/README.Rmd
@@ -22,13 +22,25 @@ knitr::opts_chunk$set(
 
 <!-- badges: end -->
 
-R package for maintaining data bases with slowly-changing-dimensions
+## Overview
+
+`SCDB` is a package for easily maintaining and updating data with a slowly changing dimension.
+More specifically, the package facilitates type-2 history for data warehouses and provide a number of quality-of-life improvements for working with SQL databases within R.
+
+To better understand what a slowly changing dimension is and how and this packages provides it,
+see `vignette("basic_principles")`.
 
 ## Installation
 
-You can install the development version of `SCDB` from [GitHub](https://github.com/) with:
+```{r, eval = FALSE}
+# Install SCDB from CRAN:
+install.packages("SCDB")
 
-``` r
+# Alternatively, install the development version from github:
 # install.packages("devtools")
-devtools::install_github("ssi-dk/SCDB")  # Use "ssi-dk/SCDB@*release" to install the latest release version
+devtools::install_github("ssi-dk/SCDB")
 ```
+
+## Usage
+
+For basic usage examples, see `vignette("basic_principles")`.

--- a/README.Rmd
+++ b/README.Rmd
@@ -1,0 +1,34 @@
+---
+output:
+  - github_document
+  - md_document
+---
+
+<!-- README.md is generated from README.Rmd. Please edit that file. -->
+
+```{r, echo = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  fig.path = "man/figures/README-"
+)
+```
+
+# SCDB <a href="https://ssi-dk.github.io/SCDB/"><img src="man/figures/logo.png" alt="SCDB website" align="right" height="138"/></a>
+
+<!-- badges: start -->
+
+[![CRAN status](https://www.r-pkg.org/badges/version/SCDB)](https://CRAN.R-project.org/package=SCDB) [![R-CMD-check](https://github.com/ssi-dk/SCDB/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/ssi-dk/SCDB/actions/workflows/R-CMD-check.yaml) [![Codecov test coverage](https://codecov.io/gh/ssi-dk/SCDB/branch/main/graph/badge.svg)](https://app.codecov.io/gh/ssi-dk/SCDB?branch=main)
+
+<!-- badges: end -->
+
+R package for maintaining data bases with slowly-changing-dimensions
+
+## Installation
+
+You can install the development version of `SCDB` from [GitHub](https://github.com/) with:
+
+``` r
+# install.packages("devtools")
+devtools::install_github("ssi-dk/SCDB")  # Use "ssi-dk/SCDB@*release" to install the latest release version
+```

--- a/README.md
+++ b/README.md
@@ -1,15 +1,24 @@
-# SCDB <a href="https://ssi-dk.github.io/SCDB/"><img src="man/figures/logo.png" align="right" height="138" alt="SCDB website" /></a>
-[![CRAN status](https://www.r-pkg.org/badges/version/SCDB)](https://CRAN.R-project.org/package=SCDB)
-[![R-CMD-check](https://github.com/ssi-dk/SCDB/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/ssi-dk/SCDB/actions/workflows/R-CMD-check.yaml)
-[![Codecov test coverage](https://codecov.io/gh/ssi-dk/SCDB/branch/main/graph/badge.svg)](https://app.codecov.io/gh/ssi-dk/SCDB?branch=main)
 
+<!-- README.md is generated from README.Rmd. Please edit that file. -->
+
+# SCDB <a href="https://ssi-dk.github.io/SCDB/"><img src="man/figures/logo.png" alt="SCDB website" align="right" height="138"/></a>
+
+<!-- badges: start -->
+
+[![CRAN
+status](https://www.r-pkg.org/badges/version/SCDB)](https://CRAN.R-project.org/package=SCDB)
+[![R-CMD-check](https://github.com/ssi-dk/SCDB/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/ssi-dk/SCDB/actions/workflows/R-CMD-check.yaml)
+[![Codecov test
+coverage](https://codecov.io/gh/ssi-dk/SCDB/branch/main/graph/badge.svg)](https://app.codecov.io/gh/ssi-dk/SCDB?branch=main)
+
+<!-- badges: end -->
 
 R package for maintaining data bases with slowly-changing-dimensions
 
-
 ## Installation
 
-You can install the development version of `SCDB` from [GitHub](https://github.com/) with:
+You can install the development version of `SCDB` from
+[GitHub](https://github.com/) with:
 
 ``` r
 # install.packages("devtools")

--- a/README.md
+++ b/README.md
@@ -13,14 +13,27 @@ coverage](https://codecov.io/gh/ssi-dk/SCDB/branch/main/graph/badge.svg)](https:
 
 <!-- badges: end -->
 
-R package for maintaining data bases with slowly-changing-dimensions
+## Overview
+
+`SCDB` is a package for easily maintaining and updating data with a
+slowly changing dimension. More specifically, the package facilitates
+type-2 history for data warehouses and provide a number of
+quality-of-life improvements for working with SQL databases within R.
+
+To better understand what a slowly changing dimension is and how and
+this packages provides it, see `vignette("basic_principles")`.
 
 ## Installation
 
-You can install the development version of `SCDB` from
-[GitHub](https://github.com/) with:
-
 ``` r
+# Install SCDB from CRAN:
+install.packages("SCDB")
+
+# Alternatively, install the development version from github:
 # install.packages("devtools")
-devtools::install_github("ssi-dk/SCDB")  # Use "ssi-dk/SCDB@*release" to install the latest release version
+devtools::install_github("ssi-dk/SCDB")
 ```
+
+## Usage
+
+For basic usage examples, see `vignette("basic_principles")`.


### PR DESCRIPTION
This makes it easier for us to document package features and examples in the future.

Additionally, I've added instructions on how to install from CRAN 🙂 