### PR TITLE
Add SSI to contributors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,9 @@ Authors@R:
 	           comment = c(ORCID = "0000-0002-5860-3838")),
 	    person("Marcus Munch", "Gr\U00FCnewald", , "mmgr@ssi.dk",
 	           role = c("aut"),
-	           comment = c(ORCID = "0009-0006-8090-406X")))
+	           comment = c(ORCID = "0009-0006-8090-406X")),
+	    person("Statens Serum Institut",
+	           role = c("cph", "fnd")))
 Maintainer: Marcus Munch Gr\U00FCnewald <mmgr@ssi.dk>
 Description: A collection of functions that enable easy access and updating of a database of data over time.
              More specifically, the package facilitates type-2 history for data-warehouses and provides a number

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -2,3 +2,7 @@ url: https://ssi-dk.github.io/SCDB/
 template:
   bootstrap: 5
 
+authors:
+  Statens Serum Institut:
+    href: http://ssi.dk
+    html: <img src='man/figures/ssi-logo.svg' alt='SSI' height='45' />

--- a/man/SCDB-package.Rd
+++ b/man/SCDB-package.Rd
@@ -26,5 +26,10 @@ Authors:
   \item Marcus Munch Grünewald \email{mmgr@ssi.dk} (\href{https://orcid.org/0009-0006-8090-406X}{ORCID})
 }
 
+Other contributors:
+\itemize{
+  \item Statens Serum Institut [copyright holder, funder]
+}
+
 }
 \keyword{internal}

--- a/man/figures/ssi-logo.svg
+++ b/man/figures/ssi-logo.svg
@@ -1,0 +1,528 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   version="1.1"
+   id="svg2"
+   width="205.67999"
+   height="75.58667"
+   viewBox="0 0 205.67999 75.58667"
+   sodipodi:docname="SSI_logo_left_P8180.eps"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs6" />
+  <sodipodi:namedview
+     id="namedview4"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1" />
+  <g
+     id="g8"
+     inkscape:groupmode="layer"
+     inkscape:label="ink_ext_XXXXXX"
+     transform="matrix(1.3333333,0,0,-1.3333333,0,75.586667)">
+    <g
+       id="g10"
+       transform="scale(0.1)">
+      <path
+         d="M 566.973,11.3281 C 566.973,5.09766 561.855,0 555.625,0 H 11.3672 C 5.13672,0 0,5.09766 0,11.3281 V 555.598 c 0,6.23 5.13672,11.328 11.3672,11.328 H 555.625 c 6.23,0 11.348,-5.098 11.348,-11.328 V 11.3281"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path12" />
+      <path
+         d="m 409.141,428.898 c 1.484,-1.41 87.851,-84.589 89.746,-86.386 -3.184,0 -11.367,0 -11.367,0 v -2.602 c 0,-34.976 23.476,-50.613 34.921,-57.254 -7.05,0 -470.8394,0 -477.8902,0 11.4453,6.641 34.9023,22.278 34.9023,57.254 v 2.602 c 0,0 -8.1836,0 -11.3476,0 1.875,1.797 88.2615,84.976 89.7265,86.386 2.07,0 249.258,0 251.309,0 z m 1.035,5.204 H 155.742 l -93.0272,-89.559 0.0196,-7.258 c 0,0 8.2422,0 11.4258,0 C 73.125,308.527 55.293,294.68 39.6484,285.84 l -1.289,-0.762 v -7.598 l 2.5976,-0.019 h 487.676 v 7.617 l -1.309,0.762 c -15.644,8.84 -33.476,22.687 -34.492,51.445 3.184,0 11.426,0 11.426,0 v 7.258 l -93.008,89.559 h -1.074"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path14" />
+      <path
+         d="M 508.242,134.805 V 280.07 H 342.48 v 12.977 c -17.597,10.398 -24.062,27.156 -24.062,49.465 h -10.41 c 0,13.535 -10.977,24.351 -24.512,24.351 -13.535,0 -24.512,-10.816 -24.512,-24.351 h -10.41 c 0,-22.309 -6.445,-39.067 -24.062,-49.465 V 280.07 H 58.75 V 134.805 H 52.6563 V 119.238 H 248.887 v 5.215 h 69.238 v -5.215 h 196.172 v 15.567 h -6.055"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path16" />
+      <path
+         d="m 283.477,205.645 c -6.016,0 -11.407,-2.598 -15.235,-6.68 h 30.449 c -3.789,4.082 -9.199,6.68 -15.214,6.68"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path18" />
+      <path
+         d="m 283.477,210.82 c 9.121,0 17.148,-4.734 21.777,-11.855 h 6.016 c -5.137,10.129 -15.645,17.031 -27.793,17.031 -12.149,0 -22.637,-6.902 -27.774,-17.031 h 5.977 c 4.648,7.121 12.656,11.855 21.797,11.855"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path20" />
+      <path
+         d="m 240.234,108.828 v -6.601 h 86.524 v 6.601 h -86.524"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path22" />
+      <path
+         d="m 234.902,287.461 v -4.805 h 97.207 v 4.805 h -97.207"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path24" />
+      <path
+         d="m 260.996,272.285 v -4.844 h 45 v 4.844 h -45"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path26" />
+      <path
+         d="m 260.996,262.063 v -4.836 h 45 v 4.836 h -45"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path28" />
+      <path
+         d="m 280.898,319.023 v 13.606 c -7.011,-1.106 -12.5,-6.621 -13.613,-13.606 h 13.613"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path30" />
+      <path
+         d="m 286.113,319.023 h 13.614 c -1.133,6.985 -6.622,12.5 -13.614,13.606 v -13.606"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path32" />
+      <path
+         d="m 280.898,313.82 h -13.613 c 1.113,-6.996 6.602,-12.5 13.613,-13.617 v 13.617"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path34" />
+      <path
+         d="m 286.113,313.82 v -13.617 c 6.992,1.117 12.481,6.621 13.614,13.617 h -13.614"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path36" />
+      <path
+         d="m 281.016,246.926 h -10.489 v -20.754 h 10.489 v 20.754"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path38" />
+      <path
+         d="m 286.23,246.926 v -20.754 h 10.235 v 20.754 H 286.23"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path40" />
+      <path
+         d="m 193.164,419.363 h -22.519 v 24.223 h 22.519 v -24.223"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path42" />
+      <path
+         d="m 193.164,450.52 h -22.519 v 6.929 h 22.519 v -6.929"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path44" />
+      <path
+         d="m 254.785,419.363 h -22.48 v 24.223 h 22.48 v -24.223"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path46" />
+      <path
+         d="m 254.785,450.52 h -22.48 v 6.929 h 22.48 v -6.929"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path48" />
+      <path
+         d="m 334.688,419.363 h -22.481 v 24.223 h 22.481 v -24.223"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path50" />
+      <path
+         d="m 334.688,450.52 h -22.481 v 6.929 h 22.481 v -6.929"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path52" />
+      <path
+         d="m 373.828,419.363 h 22.5 v 24.223 h -22.5 v -24.223"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path54" />
+      <path
+         d="m 373.828,450.52 h 22.5 v 6.929 h -22.5 v -6.929"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path56" />
+      <path
+         d="m 90.5664,342.512 v -4.864 H 238.203 v 4.864 H 90.5664"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path58" />
+      <path
+         d="m 476.426,342.512 v -4.864 H 328.789 v 4.864 h 147.637"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path60" />
+      <path
+         d="M 75,272.305 V 145.188 h 5.2148 V 272.305 H 75"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path62" />
+      <path
+         d="M 229.688,272.305 V 145.188 h 5.195 v 127.117 h -5.195"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path64" />
+      <path
+         d="m 100.957,262.063 v 10.242 H 90.5664 v -10.242 h 10.3906"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path66" />
+      <path
+         d="m 106.152,262.063 h 10.371 v 10.242 h -10.371 v -10.242"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path68" />
+      <path
+         d="m 106.152,256.863 v -19.175 h 10.371 v 19.175 h -10.371"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path70" />
+      <path
+         d="M 100.957,256.863 H 90.5664 v -19.175 h 10.3906 v 19.175"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path72" />
+      <path
+         d="m 106.152,159.727 v -14.539 h 10.371 v 14.539 h -10.371"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path74" />
+      <path
+         d="M 100.957,159.727 H 90.5664 v -14.539 h 10.3906 v 14.539"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path76" />
+      <path
+         d="m 100.957,201.309 v 18.183 H 90.5664 v -18.183 h 10.3906"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path78" />
+      <path
+         d="m 106.152,201.309 h 10.371 v 18.183 h -10.371 v -18.183"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path80" />
+      <path
+         d="M 100.957,196.105 H 90.5664 V 177.91 h 10.3906 v 18.195"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path82" />
+      <path
+         d="M 106.152,196.105 V 177.91 h 10.371 v 18.195 h -10.371"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path84" />
+      <path
+         d="m 152.344,262.063 v 10.242 h -10.371 v -10.242 h 10.371"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path86" />
+      <path
+         d="m 157.52,262.063 h 10.41 v 10.242 h -10.41 v -10.242"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path88" />
+      <path
+         d="m 157.52,256.863 v -19.175 h 10.41 v 19.175 h -10.41"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path90" />
+      <path
+         d="m 152.344,256.863 h -10.371 v -19.175 h 10.371 v 19.175"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path92" />
+      <path
+         d="m 157.52,159.727 v -14.539 h 10.41 v 14.539 h -10.41"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path94" />
+      <path
+         d="m 152.344,159.727 h -10.371 v -14.539 h 10.371 v 14.539"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path96" />
+      <path
+         d="m 152.344,201.309 v 18.183 h -10.371 v -18.183 h 10.371"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path98" />
+      <path
+         d="m 157.52,201.309 h 10.41 v 18.183 h -10.41 v -18.183"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path100" />
+      <path
+         d="M 152.344,196.105 H 141.973 V 177.91 h 10.371 v 18.195"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path102" />
+      <path
+         d="M 157.52,196.105 V 177.91 h 10.41 v 18.195 h -10.41"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path104" />
+      <path
+         d="m 203.75,262.063 v 10.242 h -10.43 v -10.242 h 10.43"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path106" />
+      <path
+         d="m 208.926,262.063 h 10.39 v 10.242 h -10.39 v -10.242"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path108" />
+      <path
+         d="m 208.926,256.863 v -19.175 h 10.39 v 19.175 h -10.39"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path110" />
+      <path
+         d="m 203.75,256.863 h -10.43 v -19.175 h 10.43 v 19.175"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path112" />
+      <path
+         d="m 208.926,159.727 v -14.539 h 10.39 v 14.539 h -10.39"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path114" />
+      <path
+         d="m 203.73,159.727 h -10.41 v -14.539 h 10.41 v 14.539"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path116" />
+      <path
+         d="m 203.73,201.309 v 18.183 h -10.41 v -18.183 h 10.41"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path118" />
+      <path
+         d="m 208.926,201.309 h 10.39 v 18.183 h -10.39 v -18.183"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path120" />
+      <path
+         d="M 203.73,196.105 H 193.32 V 177.91 h 10.41 v 18.195"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path122" />
+      <path
+         d="M 208.926,196.105 V 177.91 h 10.39 v 18.195 h -10.39"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path124" />
+      <path
+         d="m 304.316,190.227 h -44.199 c 0,0 0,-50.684 0,-55.422 -5.058,0 -190.9959,0 -190.9959,0 V 129.98 H 265.313 c 0,0 0,50.352 0,55.047 4.238,0 32.148,0 36.406,0 0,-4.695 0,-55.047 0,-55.047 h 196.152 v 4.825 c 0,0 -185.918,0 -190.976,0 0,4.738 0,55.422 0,55.422 h -2.579"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path126" />
+      <path
+         d="M 286.23,164.297 V 129.98 h 10.235 v 34.317 H 286.23"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path128" />
+      <path
+         d="m 296.465,169.492 v 10.371 h -25.938 v -10.371 h 25.938"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path130" />
+      <path
+         d="M 281.016,164.297 H 270.527 V 129.98 h 10.489 v 34.317"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path132" />
+      <path
+         d="m 157.52,306.027 h 10.41 v 7.793 h -10.41 v -7.793"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path134" />
+      <path
+         d="m 141.973,306.027 h 10.39 v 7.793 h -10.39 v -7.793"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path136" />
+      <path
+         d="m 141.973,293.066 h 10.39 v 7.786 h -10.39 v -7.786"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path138" />
+      <path
+         d="m 157.52,293.066 h 10.41 v 7.786 h -10.41 v -7.786"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path140" />
+      <path
+         d="m 154.961,329.285 -0.684,-0.242 -17.148,-5.809 v -4.496 c 5.351,1.821 16.836,5.715 17.832,6.039 0.977,-0.324 12.461,-4.218 17.812,-6.039 v 4.496 l -17.812,6.051"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path142" />
+      <path
+         d="M 491.973,272.305 V 145.188 h -5.196 v 127.117 h 5.196"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path144" />
+      <path
+         d="M 337.305,272.305 V 145.188 h -5.196 v 127.117 h 5.196"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path146" />
+      <path
+         d="m 466.016,262.063 v 10.242 h 10.39 v -10.242 h -10.39"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path148" />
+      <path
+         d="m 460.84,262.063 h -10.391 v 10.242 h 10.391 v -10.242"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path150" />
+      <path
+         d="m 460.84,256.863 v -19.175 h -10.391 v 19.175 h 10.391"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path152" />
+      <path
+         d="m 466.016,256.863 h 10.39 v -19.175 h -10.39 v 19.175"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path154" />
+      <path
+         d="m 460.84,159.727 v -14.539 h -10.391 v 14.539 h 10.391"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path156" />
+      <path
+         d="m 466.016,159.727 h 10.39 v -14.539 h -10.39 v 14.539"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path158" />
+      <path
+         d="m 466.016,201.309 v 18.183 h 10.39 v -18.183 h -10.39"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path160" />
+      <path
+         d="m 460.84,201.309 h -10.391 v 18.183 h 10.391 v -18.183"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path162" />
+      <path
+         d="m 466.016,196.105 h 10.39 V 177.91 h -10.39 v 18.195"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path164" />
+      <path
+         d="M 460.84,196.105 V 177.91 h -10.391 v 18.195 h 10.391"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path166" />
+      <path
+         d="m 414.629,262.063 v 10.242 h 10.41 v -10.242 h -10.41"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path168" />
+      <path
+         d="m 409.453,262.063 h -10.39 v 10.242 h 10.39 v -10.242"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path170" />
+      <path
+         d="m 409.453,256.863 v -19.175 h -10.39 v 19.175 h 10.39"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path172" />
+      <path
+         d="m 414.629,256.863 h 10.41 v -19.175 h -10.41 v 19.175"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path174" />
+      <path
+         d="m 409.453,159.727 v -14.539 h -10.39 v 14.539 h 10.39"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path176" />
+      <path
+         d="m 414.629,159.727 h 10.41 v -14.539 h -10.41 v 14.539"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path178" />
+      <path
+         d="m 414.629,201.309 v 18.183 h 10.41 v -18.183 h -10.41"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path180" />
+      <path
+         d="m 409.453,201.309 h -10.39 v 18.183 h 10.39 v -18.183"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path182" />
+      <path
+         d="m 414.629,196.105 h 10.41 V 177.91 h -10.41 v 18.195"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path184" />
+      <path
+         d="M 409.453,196.105 V 177.91 h -10.39 v 18.195 h 10.39"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path186" />
+      <path
+         d="m 363.242,262.063 v 10.242 h 10.391 v -10.242 h -10.391"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path188" />
+      <path
+         d="m 358.066,262.063 h -10.371 v 10.242 h 10.371 v -10.242"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path190" />
+      <path
+         d="m 358.066,256.863 v -19.175 h -10.371 v 19.175 h 10.371"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path192" />
+      <path
+         d="m 363.242,256.863 h 10.391 v -19.175 h -10.391 v 19.175"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path194" />
+      <path
+         d="m 358.066,159.727 v -14.539 h -10.371 v 14.539 h 10.371"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path196" />
+      <path
+         d="m 363.242,159.727 h 10.391 v -14.539 h -10.391 v 14.539"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path198" />
+      <path
+         d="m 363.242,201.309 v 18.183 h 10.391 v -18.183 h -10.391"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path200" />
+      <path
+         d="m 358.066,201.309 h -10.371 v 18.183 h 10.371 v -18.183"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path202" />
+      <path
+         d="m 363.242,196.105 h 10.391 V 177.91 h -10.391 v 18.195"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path204" />
+      <path
+         d="M 358.066,196.105 V 177.91 h -10.371 v 18.195 h 10.371"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path206" />
+      <path
+         d="m 409.453,306.027 h -10.39 v 7.793 h 10.39 v -7.793"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path208" />
+      <path
+         d="m 425,306.027 h -10.371 v 7.793 H 425 v -7.793"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path210" />
+      <path
+         d="m 425,293.066 h -10.371 v 7.786 H 425 v -7.786"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path212" />
+      <path
+         d="m 409.453,293.066 h -10.39 v 7.786 h 10.39 v -7.786"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path214" />
+      <path
+         d="m 412.031,329.285 0.684,-0.242 17.148,-5.809 v -4.496 c -5.351,1.821 -16.855,5.715 -17.832,6.039 -0.976,-0.324 -12.461,-4.218 -17.832,-6.039 v 4.496 l 17.832,6.051"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path216" />
+      <path
+         d="m 794.797,562.922 v -11.875 c 0,0 33.394,0 38.101,0 0,-5.195 0,-111.231 0,-111.231 h 13.223 c 0,0 0,106.036 0,111.231 4.707,0 38.109,0 38.109,0 v 11.875 h -89.433"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path218" />
+      <path
+         d="m 1024.19,562.922 v -11.875 c 0,0 33.36,0 38.09,0 0,-5.195 0,-111.231 0,-111.231 h 13.22 c 0,0 0,106.036 0,111.231 4.71,0 38.1,0 38.1,0 v 11.875 h -89.41"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path220" />
+      <path
+         d="m 1231.9,551.047 v 11.875 h -76.19 V 439.816 h 76.19 v 11.875 c 0,0 -57.79,0 -62.79,0 v 45.418 c 5,0 61.04,0 61.04,0 v 11.875 c 0,0 -56.04,0 -61.04,0 v 42.063 c 5,0 62.79,0 62.79,0"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path222" />
+      <path
+         d="m 957.527,551.398 c 1.133,-3.3 19.629,-57.441 21.797,-63.75 h -47.945 c 2.144,6.309 20.684,60.45 21.812,63.75 z m 9.868,11.524 H 943.352 L 901.418,439.816 h 13.648 c 0,0 11.25,32.989 12.407,36.309 h 55.797 c 1.156,-3.32 12.421,-36.309 12.421,-36.309 h 13.599 l -41.895,123.106"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path224" />
+      <path
+         d="m 1367.26,562.922 c 0,0 0,-106.367 0,-111.582 h -2.93 c -1.53,2.769 -60.88,111.582 -60.88,111.582 h -24.59 V 439.816 h 13.04 c 0,0 0,106.387 0,111.582 h 3.44 c 1.51,-2.773 60.55,-111.582 60.55,-111.582 h 24.41 v 123.106 h -13.04"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path226" />
+      <path
+         d="m 767.395,475.695 c 0,32.735 -22.524,33.184 -45.957,33.535 l -5.684,0.059 c -18.984,0.176 -28.242,1.024 -28.242,19.922 0,19.883 7.5,24.441 34.336,24.441 16.187,0 36.636,-1.648 36.636,-1.648 l 0.176,11.484 c 0,0 -18.316,1.805 -38.199,1.805 -27.465,0 -47.309,-3.184 -47.309,-36.27 0,-32.214 21.875,-32.664 44.629,-32.996 l 6.43,-0.089 c 18.926,-0.204 28.672,-0.165 28.672,-20.801 0,-19.871 -7.5,-24.442 -34.36,-24.442 -16.152,0 -38.535,1.66 -38.535,1.66 l -0.175,-11.488 c 0,0 20.214,-1.812 40.136,-1.812 27.446,0 47.446,3.281 47.446,36.64"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path228" />
+      <path
+         d="m 1519.29,475.695 c 0,32.735 -22.52,33.184 -45.98,33.535 l -5.66,0.059 c -19.01,0.176 -28.27,1.024 -28.27,19.922 0,19.883 7.5,24.441 34.34,24.441 16.19,0 36.64,-1.648 36.64,-1.648 l 0.18,11.484 c 0,0 -18.3,1.805 -38.21,1.805 -27.46,0 -47.3,-3.184 -47.3,-36.27 0,-32.214 21.87,-32.664 44.65,-32.996 l 6.42,-0.089 c 18.93,-0.204 28.68,-0.165 28.68,-20.801 0,-19.871 -7.5,-24.442 -34.36,-24.442 -16.17,0 -38.55,1.66 -38.55,1.66 l -0.16,-11.488 c 0,0 20.21,-1.812 40.12,-1.812 27.46,0 47.46,3.281 47.46,36.64"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path230" />
+      <path
+         d="m 1163.63,275.273 c 0,1.934 -0.06,72.649 -0.06,72.649 h -13.22 l 0.02,-63.891 c 0,-20.203 0,-30.34 -3.55,-36.824 -4.11,-7.344 -12.95,-10.937 -27.05,-10.937 -14.16,0 -23.38,3.691 -27.43,10.937 -3.16,5.606 -3.12,14.531 -3.02,30.703 l 0.02,70.012 h -13.25 l -0.04,-66.27 c -0.13,-11.269 -0.33,-28.312 2.86,-36.73 3.8,-9.824 13.98,-21.531 40.86,-21.531 18.71,0 30.76,5.3 37.93,16.609 5.33,8.34 5.93,21.23 5.93,35.273"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path232" />
+      <path
+         d="m 890.996,336.047 v 11.875 H 814.805 V 224.805 h 76.191 v 11.875 c 0,0 -57.793,0 -62.793,0 v 45.41 c 4.981,0 61.016,0 61.016,0 v 11.894 c 0,0 -56.035,0 -61.016,0 v 42.063 c 5,0 62.793,0 62.793,0"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path234" />
+      <path
+         d="m 1317.97,347.922 c 0,0 -35.74,-87.453 -37.07,-90.734 h -3.73 c -1.35,3.281 -37.11,90.734 -37.11,90.734 h -24.65 V 224.805 h 12.87 c 0,0 0,106.394 0,111.593 h 3.07 c 1.35,-3.273 36.87,-90.734 36.87,-90.734 h 21.6 c 0,0 35.55,87.461 36.88,90.734 h 3.05 c 0,-5.199 0,-111.593 0,-111.593 h 12.87 v 123.117 h -24.65"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path236" />
+      <path
+         d="m 1014.55,313.965 c 0,-7.938 -1.48,-13.895 -4.49,-16.902 -4.45,-4.426 -12.872,-4.375 -23.517,-4.309 0,0 -26.152,0.019 -30.684,0.019 v 43.45 c 4.512,0 28.243,0 28.243,0 11.601,0.039 20.758,0.054 25.698,-4.844 3.21,-3.184 4.75,-9.316 4.75,-17.414 z m 22.29,-89.16 -28.17,57.851 c 0.86,0.235 1.7,0.528 2.54,0.84 4.92,1.863 16.41,7.168 16.41,29.949 0,12.66 -2.56,21.098 -8.05,26.567 -7.95,7.949 -20.644,7.91 -35.332,7.91 H 942.656 V 224.805 h 13.203 c 0,0 0,50.957 0,55.918 4.512,0 25.274,0 25.274,0 5.722,0 10.234,0.05 14.004,0.195 l 27.203,-56.113 h 14.5"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path238" />
+      <path
+         d="m 767.637,260.723 c 0,32.734 -22.52,33.175 -45.977,33.547 l -5.683,0.078 c -18.985,0.156 -28.243,1.011 -28.243,19.898 0,19.875 7.5,24.453 34.336,24.453 16.172,0 36.641,-1.656 36.641,-1.656 l 0.176,11.484 c 0,0 -18.321,1.817 -38.203,1.817 -27.481,0 -47.305,-3.196 -47.305,-36.289 0,-32.219 21.875,-32.649 44.629,-32.981 l 6.445,-0.09 c 18.906,-0.203 28.672,-0.183 28.672,-20.808 0,-19.883 -7.5,-24.442 -34.355,-24.442 -16.172,0 -38.555,1.668 -38.555,1.668 l -0.176,-11.484 c 0,0 20.234,-1.824 40.137,-1.824 27.461,0 47.461,3.277 47.461,36.629"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path240" />
+      <path
+         d="m 845,130.07 c 0,0 0,-106.4177 0,-111.5934 h -2.93 C 840.566,21.25 781.211,130.07 781.211,130.07 h -24.59 V 6.94531 h 13.027 c 0,0 0,106.39469 0,111.58169 h 3.457 C 774.609,115.773 833.672,6.94531 833.672,6.94531 h 24.375 V 130.07 H 845"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path242" />
+      <path
+         d="M 686.816,130.07 V 6.94531 h 13.223 V 130.07 h -13.223"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path244" />
+      <path
+         d="m 1006,130.07 v -11.886 c 0,0 33.38,0 38.1,0 0,-5.196 0,-111.23869 0,-111.23869 h 13.22 c 0,0 0,106.04269 0,111.23869 4.69,0 38.09,0 38.09,0 V 130.07 H 1006"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path246" />
+      <path
+         d="M 1137.52,130.07 V 6.94531 h 13.22 V 130.07 h -13.22"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path248" />
+      <path
+         d="m 1194.16,130.07 v -11.886 c 0,0 33.38,0 38.09,0 0,-5.196 0,-111.23869 0,-111.23869 h 13.24 c 0,0 0,106.04269 0,111.23869 4.71,0 38.08,0 38.08,0 v 11.886 h -89.41"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path250" />
+      <path
+         d="m 1412.17,57.4219 c 0,1.914 -0.04,72.6481 -0.04,72.6481 h -13.22 V 66.1719 c 0,-20.2149 0,-30.3516 -3.56,-36.836 -4.08,-7.3437 -12.95,-10.9179 -27.03,-10.9179 -14.16,0 -23.4,3.6718 -27.44,10.9179 -3.15,5.625 -3.11,14.5235 -3.05,30.7149 l 0.04,70.0192 h -13.22 l -0.04,-66.2614 c -0.14,-11.3086 -0.33,-28.3398 2.83,-36.7578 3.83,-9.832 14.01,-21.52346 40.88,-21.52346 18.71,0 30.76,5.27346 37.91,16.60156 5.37,8.3399 5.94,21.2305 5.94,35.293"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path252" />
+      <path
+         d="m 1453.18,130.07 v -11.886 c 0,0 33.38,0 38.11,0 0,-5.196 0,-111.23869 0,-111.23869 h 13.22 c 0,0 0,106.04269 0,111.23869 4.71,0 38.11,0 38.11,0 v 11.886 h -89.44"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path254" />
+      <path
+         d="m 990.156,42.8594 c 0,32.7461 -22.519,33.1875 -45.976,33.5586 l -5.684,0.0468 c -18.984,0.1758 -28.242,1.0157 -28.242,19.9141 0,19.8911 7.519,24.4411 34.355,24.4411 16.172,0 36.641,-1.66 36.641,-1.66 l 0.156,11.504 c 0,0 -18.301,1.816 -38.203,1.816 -27.461,0 -47.305,-3.183 -47.305,-36.2808 0,-32.2344 21.875,-32.6719 44.629,-32.9844 l 6.446,-0.0898 c 18.906,-0.1953 28.672,-0.1953 28.672,-20.8008 0,-19.8828 -7.5,-24.4648 -34.356,-24.4648 -16.152,0 -38.555,1.6719 -38.555,1.6719 L 902.559,8.04688 c 0,0 20.234,-1.81641 40.136,-1.81641 27.461,0 47.461,3.28125 47.461,36.62893"
+         style="fill:#74808f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path256" />
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
This adds Statens Serum Institut (SSI) to the list of contributors (so that it shows up on e.g. the pkgdown page), similar to what [tidyverse](http://tidyverse.tidyverse.org) do with RStudio (and tidyverse packages do with Posit).