### PR TITLE
docs: remove db_timestamp.NULL from reference

### DIFF
--- a/R/db_timestamps.R
+++ b/R/db_timestamps.R
@@ -22,7 +22,6 @@ db_timestamp.default <- function(timestamp, conn) {
   return(dbplyr::translate_sql(as.POSIXct(!!timestamp), con = conn))
 }
 
-#' @rdname db_timestamp
 #' @export
 db_timestamp.NULL <- function(timestamp, conn) {
   if (inherits(timestamp, "POSIXt")) timestamp <- format(timestamp)

--- a/man/db_timestamp.Rd
+++ b/man/db_timestamp.Rd
@@ -3,15 +3,12 @@
 \name{db_timestamp}
 \alias{db_timestamp}
 \alias{db_timestamp.default}
-\alias{db_timestamp.NULL}
 \alias{db_timestamp.SQLiteConnection}
 \title{Determine the type of timestamps the DB supports}
 \usage{
 db_timestamp(timestamp, conn = NULL)
 
 \method{db_timestamp}{default}(timestamp, conn)
-
-\method{db_timestamp}{`NULL`}(timestamp, conn)
 
 \method{db_timestamp}{SQLiteConnection}(timestamp, conn)
 }


### PR DESCRIPTION
<!-- Thanks for contributing!

Before creating your pull request, please read this comment in its entirety.
This will help with reviewing the changes and hopefully merge your changes into
the repository as smoothly as possible.


# Pull request title

Your title should be short yet exhaustive. Hopefully, this comes easily,
as pull requests should be single-topic as possible.


# Issue references
Ideally, the PR addresses an issue. If so, please reference the issue number
in the PR title and/or the body text. See also "Linking a pull request to an issue"
linked in the "Intent" section.


# Automated tests
The package supports several backends, and tests the coverage of these.
If the pull request modifies code which is used by multiple backends, please
test the changes locally before submitting a pull request if possible.
-->

### Intent
This PR fixes #48 


### Approach
The issue seems to stem pkgdown parsing of the db_timestamp.NULL method
(others have an open PR with a similar issue https://github.com/alexanderbrenning/wiml/pull/4)

db_timestamp.NULL is excluded from the .rd generation to suppress this issue.

### Known issues
db_timestamp.NULL is not in the package reference / documentation

### Checklist

* [x] The PR passes all local unit tests
* [x] I have documented any new features introduced
* [x] If the PR adds a new feature, please add an entry in `NEWS.md`
* [x] A reviewer is assigned to this PR
