### PR TITLE
pkgdown.yaml improvements

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -64,7 +64,7 @@ jobs:
     name: Deploy to GitHub pages 🚀
     runs-on: ubuntu-latest
     if: ${{ (github.repository == 'ssi-dk/SCDB') && (github.event_name == 'release') }}
-    needs: cleanup
+    needs: [cleanup, pkgdown-build]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,6 +1,10 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
+  push:
+    branch: main
+  pull_request:
+    branch: main
   release:
     types: [published]
   workflow_dispatch:
@@ -15,6 +19,7 @@ jobs:
 
     steps:
       - name: 🗑 Delete previous deployments
+        if: github.repository == 'ssi-dk/SCDB'
         uses: strumwolf/delete-deployment-environment@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -25,10 +25,9 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           environment: github-pages
           onlyRemoveDeployments: true
-  pkgdown:
-    # Cleanup previous deployments
+
+  pkgdown-build:
     name: Build and deploy GitHub Pages
-    needs: cleanup
     runs-on: ubuntu-latest
     # Only restrict concurrency for non-PR jobs
     concurrency:

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Upload output to artifact
         uses: actions/upload-artifact@v3
         with:
-          name: pkgdown-output
+          name: pkgdown
           path: docs/
 
   deploy:

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -27,7 +27,7 @@ jobs:
           onlyRemoveDeployments: true
 
   pkgdown-build:
-    name: Build and deploy GitHub Pages
+    name: Render pkgdown output
     runs-on: ubuntu-latest
     # Only restrict concurrency for non-PR jobs
     concurrency:
@@ -54,7 +54,7 @@ jobs:
         run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
         shell: Rscript {0}
 
-      - name: Upload output to artifact
+      - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
           name: pkgdown
@@ -68,7 +68,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Download pkgdown output artifact
+      - name: Download pkgdown output
         uses: actions/download-artifact@v3
         with:
           name: pkgdown

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -54,8 +54,27 @@ jobs:
         run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
         shell: Rscript {0}
 
+      - name: Upload output to artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: pkgdown-output
+          path: docs/
+
+  deploy:
+    name: Deploy to GitHub pages 🚀
+    runs-on: ubuntu-latest
+    if: ${{ (github.repository == 'ssi-dk/SCDB') && (github.event_name == 'release') }}
+    needs: cleanup
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Download pkgdown output artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: pkgdown
+          path: docs
+
       - name: Deploy to GitHub pages 🚀
-        if: github.event_name != 'pull_request'
         uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:
           clean: false

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: 🗑 Delete previous deployments
-        if: github.repository == 'ssi-dk/SCDB'
+        if: ${{ (github.repository == 'ssi-dk/SCDB') && (github.event_name == 'release') }}
         uses: strumwolf/delete-deployment-environment@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- Thanks for contributing!

Before creating your pull request, please read this comment in its entirety.
This will help with reviewing the changes and hopefully merge your changes into
the repository as smoothly as possible.


# Pull request title

Your title should be short yet exhaustive. Hopefully, this comes easily,
as pull requests should be single-topic as possible.


# Issue references
Ideally, the PR addresses an issue. If so, please reference the issue number
in the PR title and/or the body text. See also "Linking a pull request to an issue"
linked in the "Intent" section.


# Automated tests
The package supports several backends, and tests the coverage of these.
If the pull request modifies code which is used by multiple backends, please
test the changes locally before submitting a pull request if possible.
-->

### Intent

This PR adds on #54 by slacking some of the strictness introduced on when actions were triggered.
More specifically, the action again triggers on pushes and PR's to main, with only the deployment to GH pages (and cleanup beforehand) being done on runs triggered by a release.

As an added bonus, an artifact is used to retain the output from pkgdown, making it available without replacing the current online documentation (which should stick to release versions).

Previously, attempting to deploy a site when a forked repository was not set up to do so would result in the run failing due to lacking write access or missing resources.
This has also been fixed.

### Approach

* Cleanup and deployment is only done on the ssi-dk/SCDB repository
* The previous `pkgdown` job is split into `pkgdown-build` and `deploy`, for clarity.
* A last step is added to `pkgdown`, uploading the `docs/` folder to an artifact.
* The `pkgdown` artifact is used for the `deploy` job.

### Known issues

Previous environments may be deleted on runs not triggered by a release, but this should not affect the state of the website.
If this is not the case, jobs.cleanup.steps[0].if should be modified in some way to only run on releases as well.

### Checklist

* [x] The PR passes all local unit tests
* [x] I have documented any new features introduced
* [x] If the PR adds a new feature, please add an entry in `NEWS.md`
* [x] A reviewer is assigned to this PR
* [ ] After merging, re-build the package so that the website shows documentation for v0.2
