### PR TITLE
Add Logger$finalize()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 
 * Package logo slightly altered to have a readable clock (@RasmusSkytte, #49)
 * Added a vignette describing the concept of a slowly changing dimension using examples (@marcusmunch, #53)
+* Added a `Logger$finalize` method which removes the `log_file` in the DB when not writing to a file (@marcusmunch, #66)
 
 ## Other news
 

--- a/R/Logger.R
+++ b/R/Logger.R
@@ -82,19 +82,14 @@ Logger <- R6::R6Class( #nolint: object_name_linter
 
     },
 
+    #' @description
+    #' Remove generated log_name from database if not writing to a file
     finalize = function() {
       if (is.null(self$log_path) &&
-          !is.null(self$log_tbl) &&
-          DBI::dbIsValid(private$log_conn)) {
+            !is.null(self$log_tbl) &&
+            DBI::dbIsValid(private$log_conn)) {
 
-        # DBI::dbTableExists expects character(1) and does not work with dbplyr::remote_name which return an ident
-        table_exists <- tryCatch(
-          {dplyr::collect(self$log_tbl); TRUE},
-          error = function(e) {
-            return(FALSE)
-          })
-
-        if (isFALSE(table_exists)) return(NULL)
+        if (!table_exists(private$log_conn, self$log_tbl)) return(NULL)
 
         expected_rows <- self$log_tbl |>
           dplyr::filter(log_file == !!self$log_filename) |>

--- a/R/Logger.R
+++ b/R/Logger.R
@@ -97,7 +97,9 @@ Logger <- R6::R6Class( #nolint: object_name_linter
           con = private$log_conn
         )
 
-        DBI::dbExecute(private$log_conn, query)
+        if (DBI::dbExecute(private$log_conn, query) != 1) {
+          rlang::abort("Something went wrong while finalizing")
+        }
       }
     },
 

--- a/R/Logger.R
+++ b/R/Logger.R
@@ -87,9 +87,8 @@ Logger <- R6::R6Class( #nolint: object_name_linter
     finalize = function() {
       if (is.null(self$log_path) &&
             !is.null(self$log_tbl) &&
-            DBI::dbIsValid(private$log_conn)) {
-
-        if (!table_exists(private$log_conn, self$log_tbl)) return(NULL)
+            DBI::dbIsValid(private$log_conn) &&
+            table_exists(private$log_conn, self$log_tbl)) {
 
         expected_rows <- self$log_tbl |>
           dplyr::filter(log_file == !!self$log_filename) |>

--- a/R/Logger.R
+++ b/R/Logger.R
@@ -97,7 +97,7 @@ Logger <- R6::R6Class( #nolint: object_name_linter
 
         query <- dbplyr::build_sql(
           "UPDATE ",
-          remote_name(self$log_tbl),
+          ident(remote_name(self$log_tbl)),
           " SET ",
           ident("log_file"),
           " = NULL WHERE ",

--- a/R/Logger.R
+++ b/R/Logger.R
@@ -82,6 +82,25 @@ Logger <- R6::R6Class( #nolint: object_name_linter
 
     },
 
+    finalize = function() {
+      if (!is.null(self$log_tbl) && is.null(self$log_path)) {
+        query <- dbplyr::build_sql(
+          "UPDATE ",
+          remote_name(self$log_tbl),
+          " SET ",
+          ident("log_file"),
+          " = NULL WHERE ",
+          ident("log_file"),
+          " = '",
+          sql(self$log_filename),
+          "'",
+          con = private$log_conn
+        )
+
+        DBI::dbExecute(private$log_conn, query)
+      }
+    },
+
     #' @description
     #' Write a line to log file
     #' @param ... `r log_dots <- "One or more character strings to be concatenated"; log_dots`

--- a/R/Logger.R
+++ b/R/Logger.R
@@ -83,7 +83,11 @@ Logger <- R6::R6Class( #nolint: object_name_linter
     },
 
     finalize = function() {
-      if (!is.null(self$log_tbl) && is.null(self$log_path)) {
+      if (is.null(self$log_path) &&
+          !is.null(self$log_tbl) &&
+          DBI::dbIsValid(private$log_conn) &&
+          DBI::dbExistsTable(private$log_conn, remote_name(self$log_tbl))) {
+
         query <- dbplyr::build_sql(
           "UPDATE ",
           remote_name(self$log_tbl),

--- a/R/get_table.R
+++ b/R/get_table.R
@@ -195,6 +195,18 @@ slice_time <- function(.data, slice_ts, from_ts = from_ts, until_ts = until_ts) 
 table_exists <- function(conn, db_table_id) {
 
   # Check arguments
+  if (inherits(db_table_id, "tbl_dbi")){
+    exists <- tryCatch({
+      collect(db_table_id)
+      return(TRUE)
+    },
+    error = function(e) {
+      return(FALSE)
+    })
+
+    return(!isFALSE(exists))
+  }
+
   assert_id_like(db_table_id)
 
   if (inherits(db_table_id, "Id")) {

--- a/R/get_table.R
+++ b/R/get_table.R
@@ -195,9 +195,9 @@ slice_time <- function(.data, slice_ts, from_ts = from_ts, until_ts = until_ts) 
 table_exists <- function(conn, db_table_id) {
 
   # Check arguments
-  if (inherits(db_table_id, "tbl_dbi")){
+  if (inherits(db_table_id, "tbl_dbi")) {
     exists <- tryCatch({
-      collect(db_table_id)
+      dplyr::collect(db_table_id)
       return(TRUE)
     },
     error = function(e) {

--- a/man/Logger.Rd
+++ b/man/Logger.Rd
@@ -45,6 +45,7 @@ The full path to the logger's log file.}
 \subsection{Public methods}{
 \itemize{
 \item \href{#method-Logger-new}{\code{Logger$new()}}
+\item \href{#method-Logger-finalize}{\code{Logger$finalize()}}
 \item \href{#method-Logger-log_info}{\code{Logger$log_info()}}
 \item \href{#method-Logger-log_warn}{\code{Logger$log_warn()}}
 \item \href{#method-Logger-log_error}{\code{Logger$log_error()}}
@@ -92,6 +93,16 @@ If NULL, no file logs are created.}
 }
 \if{html}{\out{</div>}}
 }
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Logger-finalize"></a>}}
+\if{latex}{\out{\hypertarget{method-Logger-finalize}{}}}
+\subsection{Method \code{finalize()}}{
+Remove generated log_name from database if not writing to a file
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Logger$finalize()}\if{html}{\out{</div>}}
+}
+
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Logger-log_info"></a>}}

--- a/tests/testthat/test-Logger.R
+++ b/tests/testthat/test-Logger.R
@@ -195,3 +195,16 @@ test_that("Logger console output may be suppressed", {
     character(0)
   )
 })
+
+test_that("Logger sets log_file to NULL in DB if not writing to file", {
+  for (conn in conns) {
+    logger <- Logger$new(log_conn = conn,
+                         log_table_id = "logs",
+                         log_path = NULL)
+
+    db_log_file <- dplyr::pull(dplyr::filter(logger$log_tbl, log_file == !!logger$log_filename))
+    expect_match(db_log_file, "^.+$")
+
+    logger$finalize()
+  }
+})

--- a/tests/testthat/test-Logger.R
+++ b/tests/testthat/test-Logger.R
@@ -203,6 +203,7 @@ test_that("Logger sets log_file to NULL in DB if not writing to file", {
                          log_path = NULL)
 
     db_log_file <- dplyr::pull(dplyr::filter(logger$log_tbl, log_file == !!logger$log_filename))
+    expect_length(db_log_file, 1)
     expect_match(db_log_file, "^.+$")
 
     logger$finalize()

--- a/tests/testthat/test-Logger.R
+++ b/tests/testthat/test-Logger.R
@@ -209,3 +209,16 @@ test_that("Logger sets log_file to NULL in DB if not writing to file", {
     logger$finalize()
   }
 })
+
+test_that("Logger$finalize handles log table is at some point deleted", {
+  for (conn in conns) {
+    log_table_id <- "expendable_log_table"
+    logger <- Logger$new(log_conn = conn,
+                         log_table_id = log_table_id,
+                         log_path = NULL)
+
+    DBI::dbRemoveTable(conn, log_table_id)
+
+    expect_no_error(logger$finalize())
+  }
+})


### PR DESCRIPTION
<!-- Thanks for contributing!

Before creating your pull request, please read this comment in its entirety.
This will help with reviewing the changes and hopefully merge your changes into
the repository as smoothly as possible.


# Pull request title

Your title should be short yet exhaustive. Hopefully, this comes easily,
as pull requests should be single-topic as possible.


# Issue references
Ideally, the PR addresses an issue. If so, please reference the issue number
in the PR title and/or the body text. See also "Linking a pull request to an issue"
linked in the "Intent" section.


# Automated tests
The package supports several backends, and tests the coverage of these.
If the pull request modifies code which is used by multiple backends, please
test the changes locally before submitting a pull request if possible.
-->

### Intent
This closes #64.

### Approach
I have added a `Logger$finalize()` function (see also [R6#finalizer in Advanced R](https://adv-r.hadley.nz/r6.html#finalizer)).
Currently, it does nothing unless `log_path` is `NULL` and `log_tbl` is not `NULL`.
The finalizer generates a query which sets all `log_file` in the DB to `NULL` if they were previously equal to `self$log_filename` (i.e. exactly what I described in #64).[^1]

For usability/readability, I added a bit of logic to `table_exists` to compensate for the shortcomings of `DBI::dbExistsTable`.

### Known issues
More feature than bud: Since the DB connection is stored within a `tbl_dbi` object, `table_exists` does not care about the `conn` argument if `db_table_id` inherits from `tbl_dbi`.

### Checklist

* [x] The PR passes all local unit tests
* [x] I have documented any new features introduced
* [x] If the PR adds a new feature, please add an entry in `NEWS.md`
* [x] A reviewer is assigned to this PR


[^1]: This is done with DBI::dbExecute as `dplyr::rows_update` (naturally) cannot match a log_file that is not NULL with one that is 🙃 .