### PR TITLE
Improvements to `test-non_ascii.R` and `test-rd-files.R`

### DIFF
--- a/tests/testthat/test-non_ascii.R
+++ b/tests/testthat/test-non_ascii.R
@@ -9,10 +9,12 @@ test_that("Code contains no non-ASCII characters", {
   # folder structures during testing, so we need to account for these differences
 
   # Look for the source of .Rd files
-  pkg_path <- devtools::as.package(".")$path
+  pkg_path <- base::system.file("", package = "SCDB")
 
   help_dir <- file.path(pkg_path, "help")
   man_dir  <- file.path(pkg_path, "man")
+
+  expect_true(any(dir.exists(c(help_dir, man_dir))))
 
   if (checkmate::test_directory_exists(help_dir)) {
 
@@ -58,8 +60,8 @@ test_that("Code contains no non-ASCII characters", {
   for (file_id in seq_along(files_to_check)) {
     non_ascii_line <- stringr::str_detect(files_to_check[[file_id]], r"{[^\x00-\x7f]}")
 
-    if(any(non_ascii_line)){
-      rel_path <- stringr::str_remove(c(r_paths, rd_paths)[file_id], paste0(devtools::as.package(".")$path, "/?"))
+    if (any(non_ascii_line)) {
+      rel_path <- stringr::str_remove(c(r_paths, rd_paths)[file_id], paste0(pkg_path, "/?"))
       n_lines <- which(non_ascii_line)
 
       msg <- sprintf("Non-ASCII character(s) in file %s line(s) %s",

--- a/tests/testthat/test-non_ascii.R
+++ b/tests/testthat/test-non_ascii.R
@@ -8,14 +8,9 @@ test_that("Code contains no non-ASCII characters", {
   # Note that `devtools::test()`, `devtools::check()` and GitHub workflows all have different
   # folder structures during testing, so we need to account for these differences
 
-  # Platform independent regex search to find root folder
-  path_regex <- stringr::str_replace(r"{(.*\/\w*(.Rcheck)?)\/.*(?=\/testthat)}", "/", .Platform$file.sep)
-  pkg_path <- stringr::str_extract(getwd(), path_regex, group = 1)
-
-  # If path contains .Rcheck, we need to add the package name to the path
-  pkg_path <- stringr::str_replace(pkg_path, r"{(\w*)(\.Rcheck)}", paste0("\\1\\2", .Platform$file.sep, "\\1"))
-
   # Look for the source of .Rd files
+  pkg_path <- devtools::as.package(".")$path
+
   help_dir <- file.path(pkg_path, "help")
   man_dir  <- file.path(pkg_path, "man")
 
@@ -30,7 +25,7 @@ test_that("Code contains no non-ASCII characters", {
 
   } else if (checkmate::test_directory_exists(man_dir)) {
 
-    rd_paths <- purrr::keep(dir(man_dir, full.names = TRUE), ~ stringr::str_detect(., ".[Rr][Dd]$"))
+    rd_paths <- dir(man_dir, pattern = "[.][Rr][Dd]$", full.names = TRUE)
     rd_files <- purrr::map(rd_paths, readLines)
     names(rd_files) <- purrr::map_chr(rd_paths, basename)
 
@@ -61,7 +56,19 @@ test_that("Code contains no non-ASCII characters", {
 
   # Check the files
   for (file_id in seq_along(files_to_check)) {
-    has_non_ascii <- purrr::some(files_to_check[[file_id]], ~ stringr::str_detect(., r"{[^\x00-\x7f]}"))
-    expect_false(has_non_ascii, label = paste("File:", names(files_to_check)[[file_id]]))
+    non_ascii_line <- stringr::str_detect(files_to_check[[file_id]], r"{[^\x00-\x7f]}")
+
+    if(any(non_ascii_line)){
+      rel_path <- stringr::str_remove(c(r_paths, rd_paths)[file_id], paste0(devtools::as.package(".")$path, "/?"))
+      n_lines <- which(non_ascii_line)
+
+      msg <- sprintf("Non-ASCII character(s) in file %s line(s) %s",
+                     rel_path,
+                     paste(n_lines, collapse = ", "))
+
+      fail(msg)
+    } else {
+      succeed()
+    }
   }
 })

--- a/tests/testthat/test-non_ascii.R
+++ b/tests/testthat/test-non_ascii.R
@@ -14,7 +14,7 @@ test_that("Code contains no non-ASCII characters", {
   help_dir <- file.path(pkg_path, "help")
   man_dir  <- file.path(pkg_path, "man")
 
-  expect_true(any(dir.exists(c(help_dir, man_dir))))
+  testthat::expect_true(any(dir.exists(c(help_dir, man_dir))))
 
   if (checkmate::test_directory_exists(help_dir)) {
 

--- a/tests/testthat/test-rd-files.R
+++ b/tests/testthat/test-rd-files.R
@@ -14,7 +14,7 @@ test_field_in_documentation <- function(field) {
   help_dir <- file.path(pkg_path, "help")
   man_dir  <- file.path(pkg_path, "man")
 
-  expect_true(any(dir.exists(c(help_dir, man_dir))))
+  testthat::expect_true(any(dir.exists(c(help_dir, man_dir))))
 
   if (checkmate::test_directory_exists(help_dir)) {
 

--- a/tests/testthat/test-rd-files.R
+++ b/tests/testthat/test-rd-files.R
@@ -9,10 +9,12 @@ test_field_in_documentation <- function(field) {
   # folder structures during testing, so we need to account for these differences
 
   # Look for the source of .Rd files
-  pkg_path <- devtools::as.package(".")$path
+  pkg_path <- base::system.file("", package = "SCDB")
 
   help_dir <- file.path(pkg_path, "help")
   man_dir  <- file.path(pkg_path, "man")
+
+  expect_true(any(dir.exists(c(help_dir, man_dir))))
 
   if (checkmate::test_directory_exists(help_dir)) {
 

--- a/tests/testthat/test-rd-files.R
+++ b/tests/testthat/test-rd-files.R
@@ -8,14 +8,9 @@ test_field_in_documentation <- function(field) {
   # Note that `devtools::test()`, `devtools::check()` and GitHub workflows all have different
   # folder structures during testing, so we need to account for these differences
 
-  # Platform independent regex search to find root folder
-  path_regex <- stringr::str_replace(r"{(.*\/\w*(.Rcheck)?)\/.*(?=\/testthat)}", "/", .Platform$file.sep)
-  pkg_path <- stringr::str_extract(getwd(), path_regex, group = 1)
-
-  # If path contains .Rcheck, we need to add the package name to the path
-  pkg_path <- stringr::str_replace(pkg_path, r"{(\w*)(\.Rcheck)}", paste0("\\1\\2", .Platform$file.sep, "\\1"))
-
   # Look for the source of .Rd files
+  pkg_path <- devtools::as.package(".")$path
+
   help_dir <- file.path(pkg_path, "help")
   man_dir  <- file.path(pkg_path, "man")
 
@@ -43,6 +38,8 @@ test_field_in_documentation <- function(field) {
 
   # Skip the "*-package.Rd" file
   rd_files <- rd_files[!stringr::str_detect(names(rd_files), "-package.[Rr][Dd]$")]
+
+  message("Found ", length(rd_files), " Rd files")
 
   # Check renaming
   for (rd_id in seq_along(rd_files)) {

--- a/tests/testthat/test-rd-files.R
+++ b/tests/testthat/test-rd-files.R
@@ -41,8 +41,6 @@ test_field_in_documentation <- function(field) {
   # Skip the "*-package.Rd" file
   rd_files <- rd_files[!stringr::str_detect(names(rd_files), "-package.[Rr][Dd]$")]
 
-  message("Found ", length(rd_files), " Rd files")
-
   # Check renaming
   for (rd_id in seq_along(rd_files)) {
     has_field <- any(stringr::str_detect(rd_files[[rd_id]], paste0(r"{\\}", field)))


### PR DESCRIPTION
<!-- Thanks for contributing!

Before creating your pull request, please read this comment in its entirety.
This will help with reviewing the changes and hopefully merge your changes into
the repository as smoothly as possible.


# Pull request title

Your title should be short yet exhaustive. Hopefully, this comes easily,
as pull requests should be single-topic as possible.


# Issue references
Ideally, the PR addresses an issue. If so, please reference the issue number
in the PR title and/or the body text. See also "Linking a pull request to an issue"
linked in the "Intent" section.


# Automated tests
The package supports several backends, and tests the coverage of these.
If the pull request modifies code which is used by multiple backends, please
test the changes locally before submitting a pull request if possible.
-->

### Intent
This PR aims to standardise the way package files are found across testing environments, hopefully fixing errors raised in CRAN pre-checks.

Additionally, if non-ASCII characters are detected, `test-non_ascii.R` also prints offending file names and line numbers.

This PR is labeled with priority as it resolves issues delaying the release of v0.2.1 (#70).

### Approach
Inconsistencies were previously caused by `system.file` (from `base`) being masked by `pkgload`. As development was typically done by calling `devtools::load_all(".")` within the R project, and as neither devtools nor pkgload are specified as dependencies in `DESCRIPTION`), this masking is done without any notice.

Explicitly using `base::system.file` avoid the masking done by `pkgload` provides consistent results across `devtools::test()`, `devtools::check()` and GitHub runners &mdash; and therefore also on CRAN, hopefully.

### Known issues
N/A

### Checklist

* [x] The PR passes all local unit tests
* [x] I have documented any new features introduced
* [x] If the PR adds a new feature, please add an entry in `NEWS.md`
* [x] A reviewer is assigned to this PR
