### PR TITLE
chore(lintr): change nolint exclusion

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,2 +1,0 @@
-linters: linters_with_defaults(
-  line_length_linter(120))

--- a/.lintr
+++ b/.lintr
@@ -1,0 +1,3 @@
+linters: linters_with_defaults(
+  line_length_linter(120))
+exclude_linter: "^ *: *([[A-z0-9_], ]*).?$"

--- a/.lintr.R
+++ b/.lintr.R
@@ -1,0 +1,5 @@
+linters <- linters_with_defaults(
+  line_length_linter(120)
+)
+
+exclude_linter <- r"{^ *: *([\w, ]*).?$}"

--- a/.lintr.R
+++ b/.lintr.R
@@ -1,5 +1,0 @@
-linters <- linters_with_defaults(
-  line_length_linter(120)
-)
-
-exclude_linter <- r"{^ *: *([\w, ]*).?$}"

--- a/R/Logger.R
+++ b/R/Logger.R
@@ -13,7 +13,7 @@
 #'                      ts = "2020-01-01 09:00:00")
 #' @return A new instance of the `Logger` [R6][R6::R6Class] class.
 #' @export
-Logger <- R6::R6Class( #nolint: object_name_linter
+Logger <- R6::R6Class( #nolint: object_name_linter, cyclocomp_linter
   classname  = "Logger",
   public = list(
 

--- a/R/update_snapshot.R
+++ b/R/update_snapshot.R
@@ -29,7 +29,7 @@
 #' @seealso filter_keys
 #' @importFrom rlang .data
 #' @export
-update_snapshot <- function(.data, conn, db_table, timestamp, filters = NULL, message = NULL, tic = Sys.time(), # nolint: cyclocomp_linter
+update_snapshot <- function(.data, conn, db_table, timestamp, filters = NULL, message = NULL, tic = Sys.time(), # nolint: cyclocomp_linter, line_length_linter
                             logger = NULL,
                             enforce_chronological_order = TRUE) {
 


### PR DESCRIPTION
<!-- Thanks for contributing!

Before creating your pull request, please read this comment in its entirety.
This will help with reviewing the changes and hopefully merge your changes into
the repository as smoothly as possible.


# Pull request title

Your title should be short yet exhaustive. Hopefully, this comes easily,
as pull requests should be single-topic as possible.


# Issue references
Ideally, the PR addresses an issue. If so, please reference the issue number
in the PR title and/or the body text. See also "Linking a pull request to an issue"
linked in the "Intent" section.


# Automated tests
The package supports several backends, and tests the coverage of these.
If the pull request modifies code which is used by multiple backends, please
test the changes locally before submitting a pull request if possible.
-->

### Intent
I have recently discovered that the parsing of `# nolint:` statements by `lintr` works differently than I expected.
(see this issue: https://github.com/r-lib/lintr/issues/2374)

Consider this example
```
N = 2   # nolint: assignment_linter
```
My expectation of the `# nolint:` behaviour, was that only the linters specified after this tag gets ignored in the linting.
That is not the case in the above example however. 
Instead all linting is disabled on the given line.

If only the `assignment_linter` should be suppressed, you need to add a `.` by default.
```
N = 2   # nolint: assignment_linter.
```
When doing so, other linters now trigger on this line (e.g. `object_name_linter`)

There are, as far as I can tell, two possible solutions:
1) Change all `# nolint:` in the code base so a period is included.
2) Change to `linter` exclusion regex so the period is not needed.

I am not in favour of implementing solution 1) since any subsequent update may slip in a `# nolint:` statement without a period which will then block all linting on the line.

This PR implements the second solution

### Approach
1) Change `.lintr` to a R file instead of ´Debian Control File´
2) Include an updated lintr `exclude_linter` regex
3) Suppress the now un-suppressed `cyclocomp_linter` in `Logger` and `update_snapshot`

### Known issues
Suppressing the `cyclocomp_linter` for `Logger` and `update_snapshot` is not best practice, but changing these functions
is outside the scope of this PR

 `# nolint:` statements now only trigger if they are the last thing on the given line[^1]
i.e.
```
# Will suppress lints by assignment_linter
N = 2   # nolint: assignment_linter                                

# Will NOT suppress lints by assignment_linter
N = 2   # nolint: assignment_linter. Some more comment text
```

### Checklist

* [x] The PR passes all local unit tests
* [ ] ~I have documented any new features introduced~
* [ ] ~If the PR adds a new feature, please add an entry in `NEWS.md`~
* [x] A reviewer is assigned to this PR

[^1]: If this is desired, the `$` can be omitted from the regex in `exclusion_linter`, but this may introduce undesired warnings in the `lintr` parsing.