### PR TITLE
Add website to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,6 +43,7 @@ Suggests:
     knitr,
     odbc,
     rmarkdown,
+    roxygen2,
     RPostgres,
     spelling,
     testthat (>= 3.0.0),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,7 +44,6 @@ Suggests:
     odbc,
     rmarkdown,
     RPostgres,
-    roxygen2,
     spelling,
     testthat (>= 3.0.0),
     tibble

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,7 +49,7 @@ Suggests:
     testthat (>= 3.0.0),
     tibble
 Language: en-US
-URL: https://github.com/ssi-dk/SCDB
+URL: https://github.com/ssi-dk/SCDB, https://ssi-dk.github.io/SCDB/
 Config/testthat/edition: 3
 BugReports: https://github.com/ssi-dk/SCDB/issues
 VignetteBuilder: knitr


### PR DESCRIPTION
### Intent

Make website more discoverable and enable linking 


### Approach

Add to DESCRIPTION URL field


### Checklist

This is a very minor change, no need to add to news.

Edit: I also removed roxygen2 from Suggests as its import is declared with the `RoxygenNote` field.