### PR TITLE
fix: Check `testthat` availabililty before return

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,8 @@
 
 * `table_exists()` now correctly gives ambiguity warning on Microsoft SQL Server and PostgreSQL backends (#80).
 
+* Fixed dplyr joins failing if `testthat` is not installed.
+
 # SCDB 0.3
 
 * Added support for Microsoft SQL Server using ODBC (#77).

--- a/R/db_joins.R
+++ b/R/db_joins.R
@@ -92,7 +92,7 @@ select_na_sql <- function(x, y, by, na_by, left = TRUE) {
 #' @return A warning that *_joins on SQL backends does not match NA by default
 #' @noRd
 join_warn <- function() {
-  if (testthat::is_testing() || !interactive()) return()
+  if (requireNamespace("testthat", quietly = TRUE) && testthat::is_testing() || !interactive()) return()
   if (identical(parent.frame(n = 2), globalenv())) {
     rlang::warn(paste("*_joins in database-backend does not match NA by default.\n",
                       "If your data contains NA, the columns with NA values must be supplied to \"na_by\",",
@@ -106,7 +106,7 @@ join_warn <- function() {
 #' @return A warning that *_joins are still experimental
 #' @noRd
 join_warn_experimental <- function() {
-  if (testthat::is_testing() || !interactive()) return()
+  if (requireNamespace("testthat", quietly = TRUE) && testthat::is_testing() || !interactive()) return()
   if (identical(parent.frame(n = 2), globalenv())) {
     rlang::warn("*_joins with na_by is stil experimental. Please report issues to rassky",
                 .frequency = "once", .frequency_id = "*_join NA warning")


### PR DESCRIPTION
### Intent
This PR fixes an issue where dplyr `*_join`s fail if testthat is not installed.

### Approach
In `join_warn()` and `join_warn_experimental()`, check if testthat is installed before calling `testthat::is_testing()`.

### Known issues
N/A

### Checklist

* [x] The PR passes all local unit tests
* [x] I have documented any new features introduced
* [x] If the PR adds a new feature, please add an entry in `NEWS.md`
* [x] A reviewer is assigned to this PR
