### PR TITLE
Update description

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Authors@R:
 	  c(person("Rasmus Skytte", "Randl\U00F8v", , "rske@ssi.dk",
 	           role = c("aut", "cre"),
 	           comment = c(ORCID = "0000-0002-5860-3838")),
-	    person("Marcus Munch", "Gr\U00FCnewald", , "mmgr@ssi.dk",
+	    person("Marcus Munch", "Gr\U00FCnewald", , ,
 	           role = c("aut"),
 	           comment = c(ORCID = "0009-0006-8090-406X")),
         person("Lasse Engbo", "Christiansen", , "lsec@ssi.dk", role = c("ctb"),

--- a/man/SCDB-package.Rd
+++ b/man/SCDB-package.Rd
@@ -24,7 +24,7 @@ Useful links:
 
 Authors:
 \itemize{
-  \item Marcus Munch Grünewald \email{mmgr@ssi.dk} (\href{https://orcid.org/0009-0006-8090-406X}{ORCID})
+  \item Marcus Munch Grünewald (\href{https://orcid.org/0009-0006-8090-406X}{ORCID})
 }
 
 Other contributors:


### PR DESCRIPTION
### Intent

This PR removes the email field for @marcusmunch in DESCRIPTION.

CRAN only requires an email field for the "Maintainer" field (`cre`), not for authors (`aut`). As my employment at Statens Serum Institut has ended, I therefore no longer have access to the email address in question. It therefore makes no sense to 

### Approach[^1]
* Removed the email field for @marcusmunch in DESCRIPTION.
* Removed the `\email` item for @marcusmunch in man/SCDB-package.Rd

### Known issues
[^1]

### Checklist

* [x] ~The PR passes all local unit tests~ [^1]
* [x] I have documented any new features introduced
* [x] If the PR adds a new feature, please add an entry in `NEWS.md`
* [ ] A reviewer is assigned to this PR

[^1]: This was done manually on the GitHub website, as I currently do not have access to the necessary R setup to run checks locally. I may have missed something and actions may fail. If so, please fix it for me :innocent: