### PR TITLE
Only create, don't write, tables with `create_table`

### DIFF
--- a/R/create_table.R
+++ b/R/create_table.R
@@ -70,7 +70,7 @@ create_table <- function(.data, conn = NULL, db_table_id, ...) {
 
   } else {
 
-    dbi_create_table_id <- db_table_id <- id(db_table_id, conn) # If permanent, use all availalbe info
+    dbi_create_table_id <- db_table_id <- id(db_table_id, conn) # If permanent, use all available info
   }
 
   # Check if the table already exists

--- a/R/create_table.R
+++ b/R/create_table.R
@@ -55,6 +55,11 @@ create_table <- function(.data, conn = NULL, db_table_id, ...) {
 
   }
 
+  # Check if the table already exists
+  if (table_exists(conn, db_table_id)) {
+    stop("Table ", db_table_id, " already exists!")
+  }
+
   # Create the table on the remote and return the table
   DBI::dbCreateTable(
     conn = conn,

--- a/R/create_table.R
+++ b/R/create_table.R
@@ -40,18 +40,18 @@ create_table <- function(.data, conn = NULL, db_table_id, ...) {
   # Convert to id
   db_table_id <- id(db_table_id, conn)
 
-  # Check db_table_id conforms to requirements
-  # Temporary tables on some back ends must to begin with "#".
-  # And DBI::dbCreateTable requires that table Ids are unqualified if they are temporary
+  # Check db_table_id conforms to requirements:
+  # 1) Temporary tables on some backends must to begin with "#".
+  # 2) DBI::dbCreateTable requires that table Ids are unqualified if the table should be temporary
   if (purrr::pluck(list(...), "temporary", .default = formals(DBI::dbCreateTable)$temporary)) {
 
-    db_table_name <- purrr::pluck(db_table_id, "name", "table")
+    table <- purrr::pluck(db_table_id, "name", "table")
 
-    if (inherits(conn, "Microsoft SQL Server") && !startsWith(db_table_name, "#")) {
-      db_table_name <- paste0("#", db_table_name)
+    if (inherits(conn, "Microsoft SQL Server") && !startsWith(table, "#")) {
+      table <- paste0("#", table)
     }
 
-    db_table_id <- DBI::Id(table = db_table_name)
+    db_table_id <- DBI::Id(table = table)
 
   }
 

--- a/tests/testthat/test-create_table.R
+++ b/tests/testthat/test-create_table.R
@@ -11,12 +11,12 @@ test_that("create_table() refuses a historical table", {
 test_that("create_table() can create temporary tables", {
   for (conn in get_test_conns()) {
 
-    table <- create_table(cars, db_table_id = "cars", conn = conn, temporary = TRUE)
+    table <- create_table(cars, db_table_id = unique_table_name(), conn = conn, temporary = TRUE)
 
     expect_identical(colnames(table), c(colnames(cars), "checksum", "from_ts", "until_ts"))
     expect_identical(
       dplyr::collect(dplyr::select(table, -tidyselect::all_of(c("checksum", "from_ts", "until_ts")))),
-      dplyr::collect(dplyr::copy_to(conn, cars, "cars_ref") |> utils::head(0))
+      dplyr::collect(dplyr::copy_to(conn, cars, unique_table_name()) |> utils::head(0))
     )
 
     connection_clean_up(conn)
@@ -27,15 +27,15 @@ test_that("create_table() can create temporary tables", {
 test_that("create_table() can create tables in default schema", {
   for (conn in get_test_conns()) {
 
-    table <- create_table(cars, db_table_id = "cars", conn = conn, temporary = FALSE)
+    table <- create_table(cars, db_table_id = unique_table_name(), conn = conn, temporary = FALSE)
+    defer_db_cleanup(table)
 
     expect_identical(colnames(table), c(colnames(cars), "checksum", "from_ts", "until_ts"))
     expect_identical(
       dplyr::collect(dplyr::select(table, -tidyselect::all_of(c("checksum", "from_ts", "until_ts")))),
-      dplyr::collect(dplyr::copy_to(conn, cars, "cars_ref") |> utils::head(0))
+      dplyr::collect(dplyr::copy_to(conn, cars, unique_table_name()) |> utils::head(0))
     )
 
-    DBI::dbRemoveTable(conn, id(table))
     connection_clean_up(conn)
   }
 })
@@ -44,22 +44,24 @@ test_that("create_table() can create tables in default schema", {
 test_that("create_table() can create tables in non default schema", {
   for (conn in get_test_conns()) {
 
-    table <- create_table(cars, db_table_id = id("test.cars", conn), conn = conn, temporary = FALSE)
+    table <- create_table(
+      cars, db_table_id = id(paste0("test.", unique_table_name()), conn), conn = conn, temporary = FALSE
+    )
+    defer_db_cleanup(table)
 
     expect_identical(colnames(table), c(colnames(cars), "checksum", "from_ts", "until_ts"))
     expect_identical(
       dplyr::collect(dplyr::select(table, -tidyselect::all_of(c("checksum", "from_ts", "until_ts")))),
-      dplyr::collect(dplyr::copy_to(conn, cars, "cars_ref") |> utils::head(0))
+      dplyr::collect(dplyr::copy_to(conn, cars, unique_table_name()) |> utils::head(0))
     )
 
-    DBI::dbRemoveTable(conn, id(table))
     connection_clean_up(conn)
   }
 })
 
 
 test_that("create_table() works with no conn", {
-  table <- create_table(cars, db_table_id = "cars", conn = NULL)
+  table <- create_table(cars, db_table_id = unique_table_name(), conn = NULL)
 
   expect_identical(colnames(table), c(colnames(cars), "checksum", "from_ts", "until_ts"))
   expect_identical(
@@ -72,16 +74,23 @@ test_that("create_table() works with no conn", {
 test_that("create_table() does not overwrite tables", {
   for (conn in get_test_conns()) {
 
-    table <- create_table(cars, db_table_id = "cars", conn = conn, temporary = TRUE)
+    table_name <- unique_table_name()
+    table <- create_table(cars, db_table_id = table_name, conn = conn, temporary = TRUE)
+
+    table_regex <- paste(
+      paste(c(get_catalog(conn, temporary = TRUE), get_schema(conn, temporary = TRUE)), collapse = "."),
+      paste0("#?", table_name),
+      sep = "."
+    )
 
     expect_error(
-      create_table(iris, db_table_id = "cars", conn = conn, temporary = TRUE),
-      regexp = r"{(?:object named)|(?:table)|(?:relation) ["'`]#?cars["'`] (?:already exists)|(?:in the database)}"
+      create_table(iris, db_table_id = table_name, conn = conn, temporary = TRUE),
+      regexp = paste("Table", table_regex, "already exists!")
     )
 
     expect_identical(
       dplyr::collect(dplyr::select(table, -tidyselect::all_of(c("checksum", "from_ts", "until_ts")))),
-      dplyr::collect(dplyr::copy_to(conn, cars, "cars_ref") |> utils::head(0))
+      dplyr::collect(dplyr::copy_to(conn, cars, unique_table_name()) |> utils::head(0))
     )
 
     connection_clean_up(conn)


### PR DESCRIPTION
<!-- Thanks for contributing!

Before creating your pull request, please read this comment in its entirety.
This will help with reviewing the changes and hopefully merge your changes into
the repository as smoothly as possible.


# Pull request title

Your title should be short yet exhaustive. Hopefully, this comes easily,
as pull requests should be single-topic as possible.


# Issue references
Ideally, the PR addresses an issue. If so, please reference the issue number
in the PR title and/or the body text. See also "Linking a pull request to an issue"
linked in the "Intent" section.


# Automated tests
The package supports several backends, and tests the coverage of these.
If the pull request modifies code which is used by multiple backends, please
test the changes locally before submitting a pull request if possible.
-->

### Intent
This small PR makes `create_table` only create, not write the given table. 

This does two nice things: 
1) The setting of column types now works (`getTableSignature`s output is understood by `DBI::dbCreateTable`, not by `DBI::dbWriteTable`)

2) The function name is now aligned wiht DBI::dbCreateTable since both only creates the table (they don't write the table)

### Approach
Internal use of `DBI::dbWriteTable` replaced with `DBI::dbCreateTable`

Early return when `conn = NULL` changed to only return `head(data, 0)`

Test updates to match this updated behaviour.

`create_table()` checks for the existence of the table before creating

### Known issues
~~This PR also contains the code being merged in~~
* [x] ~~https://github.com/ssi-dk/SCDB/pull/107~~
~~Once merged, this PR will be rebased and opened.~~

~~Tests for PostgreSQL are showing as failing.~~
~~This is caused by an update to the Workflows so that previously undetected errors are now being explicitly shown.~~
~~The source of the error is being fixed in #98~~ 

### Checklist

* [x] The PR passes all local unit tests
* [x] I have documented any new features introduced
* [x] If the PR adds a new feature, please add an entry in `NEWS.md`
* [x] A reviewer is assigned to this PR
