### PR TITLE
Hexadecimal checksums on Microsoft SQL Server

### DIFF
--- a/R/getTableSignature.R
+++ b/R/getTableSignature.R
@@ -26,17 +26,17 @@ methods::setMethod("getTableSignature", "DBIConnection", function(.data, conn) {
       until_ts = "TIMESTAMP"  # Stored internally as TEXT
     ),
     "PqConnection" = c(
-      checksum = "VARCHAR(32)",
+      checksum = "CHAR(32)",
       from_ts  = "TIMESTAMP",
       until_ts = "TIMESTAMP"
     ),
     "Microsoft SQL Server" = c(
-      checksum = "varchar(40)",
+      checksum = "CHAR(64)",
       from_ts  = "DATETIME",
       until_ts = "DATETIME"
     ),
     "duckdb_connection" = c(
-      checksum = "varchar(32)",
+      checksum = "char(32)",
       from_ts  = "TIMESTAMP",
       until_ts = "TIMESTAMP"
     )

--- a/tests/testthat/test-getTableSignature.R
+++ b/tests/testthat/test-getTableSignature.R
@@ -83,7 +83,7 @@ for (conn in c(list(NULL), get_test_conns())) {
           "numeric"   = "DOUBLE PRECISION",
           "logical"   = "BOOLEAN",
           # ..
-          "checksum"  = "VARCHAR(32)",
+          "checksum"  = "CHAR(32)",
           "from_ts"   = "TIMESTAMP",
           "until_ts"  = "TIMESTAMP"
         )
@@ -103,7 +103,7 @@ for (conn in c(list(NULL), get_test_conns())) {
           "numeric"   = "FLOAT",
           "logical"   = "BIT",
           # ..
-          "checksum"  = "varchar(40)",
+          "checksum"  = "CHAR(64)",
           "from_ts"   = "DATETIME",
           "until_ts"  = "DATETIME"
         )
@@ -123,7 +123,7 @@ for (conn in c(list(NULL), get_test_conns())) {
           "numeric"   = "DOUBLE",
           "logical"   = "BOOLEAN",
           # ..
-          "checksum"  = "varchar(32)",
+          "checksum"  = "char(32)",
           "from_ts"   = "TIMESTAMP",
           "until_ts"  = "TIMESTAMP"
         )


### PR DESCRIPTION
<!-- Thanks for contributing!

Before creating your pull request, please read this comment in its entirety.
This will help with reviewing the changes and hopefully merge your changes into
the repository as smoothly as possible.


# Pull request title

Your title should be short yet exhaustive. Hopefully, this comes easily,
as pull requests should be single-topic as possible.


# Issue references
Ideally, the PR addresses an issue. If so, please reference the issue number
in the PR title and/or the body text. See also "Linking a pull request to an issue"
linked in the "Intent" section.


# Automated tests
The package supports several backends, and tests the coverage of these.
If the pull request modifies code which is used by multiple backends, please
test the changes locally before submitting a pull request if possible.
-->

### Intent
This PR introduces a few minor improvements to the Microsoft SQL Server support

### Approach
* Checksum computation is changed to be hexidecimal

* `checksum` column for MSSQL is changed to char(64) (SHA2-256 is 64 hex bytes)

* `checksum` column for non-MSSQL is changed to char(32) (no need to be variable)

### Known issues
Checks are failing due to the merger of #114.
The errors should only be caused by the missing dbplyr export (`dbplyr::table_path_components`) which will be available in the next release



### Checklist

* [x] The PR passes all local unit tests
* [ ] I have documented any new features introduced
* [ ] If the PR adds a new feature, please add an entry in `NEWS.md`
* [x] A reviewer is assigned to this PR
