### PR TITLE
feat(log_to_db): Throw error if logger is finalized

### DIFF
--- a/R/Logger.R
+++ b/R/Logger.R
@@ -180,6 +180,11 @@ Logger <- R6::R6Class(                                                          
     #'   Structured data written to database log table. Name indicates column and value indicates value to be written.
     log_to_db = function(...) {
 
+      # If log is finalized, throw an error to the user
+      if (private$finalized) {
+        stop("Logger has already been finalized. Cannot write to database log table.")
+      }
+
       # Only write if we have a valid connection
       if (!is.null(private$log_conn) && DBI::dbIsValid(private$log_conn) && !is.null(self$log_tbl) &&
             table_exists(private$log_conn, private$log_table_id)) {

--- a/tests/testthat/test-Logger.R
+++ b/tests/testthat/test-Logger.R
@@ -389,6 +389,13 @@ test_that("Logger: log_file is NULL in DB if not writing to file", {
     db_log_file <- dplyr::pull(dplyr::filter(logger$log_tbl, log_file == !!logger$log_filename))
     expect_length(db_log_file, 0)
 
+    # Test that an error is thrown if the database record has been finalized
+    expect_error(
+      logger$log_to_db(message = "This should produce an error"),
+      r"{Logger has already been finalized\. Cannot write to database log table\.}"
+    )
+
+
     # Clean up
     rm(logger)
     invisible(gc())


### PR DESCRIPTION
<!-- Thanks for contributing!

Before creating your pull request, please read this comment in its entirety.
This will help with reviewing the changes and hopefully merge your changes into
the repository as smoothly as possible.


# Pull request title

Your title should be short yet exhaustive. Hopefully, this comes easily,
as pull requests should be single-topic as possible.


# Issue references
Ideally, the PR addresses an issue. If so, please reference the issue number
in the PR title and/or the body text. See also "Linking a pull request to an issue"
linked in the "Intent" section.


# Automated tests
The package supports several backends, and tests the coverage of these.
If the pull request modifies code which is used by multiple backends, please
test the changes locally before submitting a pull request if possible.
-->

### Intent
This PR improves the error messages being given when attempting to write the database log after the logger has been finalized.

### Approach
`$log_to_db()` now throws an error if the `finalized` flag has been set `TRUE`


### Known issues
Checks are failing due to the merger of #114.
The errors should only be caused by the missing dbplyr export (`dbplyr::table_path_components`) which will be available in the next release


### Checklist

* [x] The PR passes all local unit tests
* [ ] I have documented any new features introduced
* [ ] If the PR adds a new feature, please add an entry in `NEWS.md`
* [x] A reviewer is assigned to this PR
