### PR TITLE
fix(unique_table_name): Add PID to ensure uniqueness

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -100,7 +100,7 @@ unique_table_name <- function(scope = "SCDB") {
   option <- paste(scope, "table_name", sep = "_")
   index <- getOption(option, default = 0) + 1
   options(tibble::lst(!!option := index))
-  return(glue::glue("{scope}_{sprintf('%03i', index)}"))
+  return(glue::glue("{scope}_{Sys.getpid()}_{sprintf('%03i', index)}"))
 }
 
 

--- a/tests/testthat/test-helpers.R
+++ b/tests/testthat/test-helpers.R
@@ -52,11 +52,11 @@ test_that("unique_table_name() works", {
   # Store options before tests and reset (tests modify options)
   opts <- options("SCDB_table_name" = NULL, "test_table_name" = NULL)
 
-  expect_equal(unique_table_name(), "SCDB_001")
-  expect_equal(unique_table_name(), "SCDB_002")
+  expect_equal(unique_table_name(), glue::glue("SCDB_{Sys.getpid()}_001"))
+  expect_equal(unique_table_name(), glue::glue("SCDB_{Sys.getpid()}_002"))
 
-  expect_equal(unique_table_name("test"), "test_001")
-  expect_equal(unique_table_name("test"), "test_002")
+  expect_equal(unique_table_name("test"), glue::glue("test_{Sys.getpid()}_001"))
+  expect_equal(unique_table_name("test"), glue::glue("test_{Sys.getpid()}_002"))
 
   # Reset options
   options(opts)


### PR DESCRIPTION
<!-- Thanks for contributing!

Before creating your pull request, please read this comment in its entirety.
This will help with reviewing the changes and hopefully merge your changes into
the repository as smoothly as possible.


# Pull request title

Your title should be short yet exhaustive. Hopefully, this comes easily,
as pull requests should be single-topic as possible.


# Issue references
Ideally, the PR addresses an issue. If so, please reference the issue number
in the PR title and/or the body text. See also "Linking a pull request to an issue"
linked in the "Intent" section.


# Automated tests
The package supports several backends, and tests the coverage of these.
If the pull request modifies code which is used by multiple backends, please
test the changes locally before submitting a pull request if possible.
-->

### Intent
This PR fixes a uniqueness issue where a table names can be duplicated across R sessions since they employ different set of `options()`. In this case, it is possible for different `unique_table_name()` calls to generate the same table name across different R sessions leading to collisions.

### Approach
The PID of the R session is inserted into the generated table name

### Known issues
N/A

### Checklist

* [x] The PR passes all local unit tests
* [ ] I have documented any new features introduced
* [ ] If the PR adds a new feature, please add an entry in `NEWS.md`
* [x] A reviewer is assigned to this PR
