### PR TITLE
fix: Stop suppressing (now deprecated) check_from messages

### DIFF
--- a/R/locks.R
+++ b/R/locks.R
@@ -48,19 +48,17 @@ lock_table <- function(conn, db_table, schema = NULL) {
 
   # Create lock table if missing
   if (!table_exists(conn, db_lock_table_id)) {
-    suppressMessages(
-      dplyr::copy_to(
-        conn,
-        data.frame(
-          "schema" = character(0),
-          "table" = character(0),
-          "user" = character(0),
-          "lock_start" = numeric(0),
-          "pid" = numeric(0)
-        ),
-        db_lock_table_id,
-        temporary = FALSE
-      )
+    dplyr::copy_to(
+      conn,
+      data.frame(
+        "schema" = character(0),
+        "table" = character(0),
+        "user" = character(0),
+        "lock_start" = numeric(0),
+        "pid" = numeric(0)
+      ),
+      db_lock_table_id,
+      temporary = FALSE
     )
 
     if (inherits(conn, "PqConnection")) { # PostgreSQL needs an index for rows_insert

--- a/data-raw/benchmark.R
+++ b/data-raw/benchmark.R
@@ -75,15 +75,9 @@ for (version in c("CRAN", "main", "branch")) {
 
     # Copy data to the conns
     data_on_conn <- list(
-      suppressMessages(
-        dplyr::copy_to(conn, data_1, name = id("test.SCDB_data_1", conn), overwrite = TRUE, temporary = FALSE)
-      ),
-      suppressMessages(
-        dplyr::copy_to(conn, data_2, name = id("test.SCDB_data_2", conn), overwrite = TRUE, temporary = FALSE)
-      ),
-      suppressMessages(
-        dplyr::copy_to(conn, data_3, name = id("test.SCDB_data_3", conn), overwrite = TRUE, temporary = FALSE)
-      )
+      dplyr::copy_to(conn, data_1, name = id("test.SCDB_data_1", conn), overwrite = TRUE, temporary = FALSE),
+      dplyr::copy_to(conn, data_2, name = id("test.SCDB_data_2", conn), overwrite = TRUE, temporary = FALSE),
+      dplyr::copy_to(conn, data_3, name = id("test.SCDB_data_3", conn), overwrite = TRUE, temporary = FALSE)
     )
 
     # Define the data to loop over for benchmark

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -38,12 +38,9 @@ for (conn in get_test_conns()) {
               ~ if (schema_exists(conn, .@name[["schema"]]) && DBI::dbExistsTable(conn, .)) DBI::dbRemoveTable(conn, .))
 
 
-  # Copy mtcars to conn (and suppress check_from message)
-  tryCatch(
-    dplyr::copy_to(conn, mtcars |> dplyr::mutate(name = rownames(mtcars)),
-                   name = id("test.mtcars", conn), temporary = FALSE, overwrite = TRUE),
-    message = \(m) if (!stringr::str_detect(m$message, stringr::fixed("check_from = FALSE"))) message(m)
-  )
+  # Copy mtcars to conn
+  dplyr::copy_to(conn, mtcars |> dplyr::mutate(name = rownames(mtcars)),
+                 name = id("test.mtcars", conn), temporary = FALSE, overwrite = TRUE)
 
   dplyr::copy_to(conn, mtcars |> dplyr::mutate(name = rownames(mtcars)),
                  name = id("__mtcars", conn), temporary = FALSE, overwrite = TRUE)

--- a/tests/testthat/test-Logger.R
+++ b/tests/testthat/test-Logger.R
@@ -91,7 +91,7 @@ test_that("Logger: logging to file works", {
 
 
   # Test logging to file has the right formatting and message type
-  suppressMessages(logger$log_info("test filewriting", tic = logger$start_time))
+  logger$log_info("test filewriting", tic = logger$start_time)
   tryCatch(logger$log_warn("test filewriting", tic = logger$start_time), warning = \(w) NULL)
   tryCatch(logger$log_error("test filewriting", tic = logger$start_time), error = \(e) NULL)
 
@@ -126,7 +126,7 @@ test_that("Logger: logging to file works", {
 
 
   # Test logging to file still works
-  suppressMessages(logger$log_info("test filewriting", tic = logger$start_time))
+  logger$log_info("test filewriting", tic = logger$start_time)
 
   ts_str <- format(logger$start_time, "%F %R:%OS3")
   expect_true(logger$log_filename %in% dir(log_path))

--- a/tests/testthat/test-db_joins.R
+++ b/tests/testthat/test-db_joins.R
@@ -32,14 +32,10 @@ test_that("*_join() works", {
     y <- data.frame(letter = c("A", "B", "A", "B"),
                     number = c(NA, "2", "1", "1"))
 
-    # Copy x and y to conn (and suppress check_from message)
-    x <- suppressMessages(
-      dplyr::copy_to(conn, x, name = id("test.SCDB_tmp1", conn), overwrite = TRUE, temporary = FALSE)
-    )
+    # Copy x and y to conn
+    x <- dplyr::copy_to(conn, x, name = id("test.SCDB_tmp1", conn), overwrite = TRUE, temporary = FALSE)
 
-    y <- suppressMessages(
-      dplyr::copy_to(conn, y, name = id("test.SCDB_tmp2", conn), overwrite = TRUE, temporary = FALSE)
-    )
+    y <- dplyr::copy_to(conn, y, name = id("test.SCDB_tmp2", conn), overwrite = TRUE, temporary = FALSE)
 
 
     q  <- dplyr::left_join(x, y, na_by = "number") |>
@@ -73,14 +69,10 @@ test_that("*_join() works", {
                     region_id = "1",
                     n_add = 4)
 
-    # Copy x and y to conn (and suppress check_from message)
-    x <- suppressMessages(
-      dplyr::copy_to(conn, x, name = id("test.SCDB_tmp1", conn), overwrite = TRUE, temporary = FALSE)
-    )
+    # Copy x and y to conn
+    x <- dplyr::copy_to(conn, x, name = id("test.SCDB_tmp1", conn), overwrite = TRUE, temporary = FALSE)
 
-    y <- suppressMessages(
-      dplyr::copy_to(conn, y, name = id("test.SCDB_tmp2", conn), overwrite = TRUE, temporary = FALSE)
-    )
+    y <- dplyr::copy_to(conn, y, name = id("test.SCDB_tmp2", conn), overwrite = TRUE, temporary = FALSE)
 
 
     q  <- dplyr::full_join(x, y, by = "date", na_by = "region_id") |>

--- a/tests/testthat/test-digest_to_checksum.R
+++ b/tests/testthat/test-digest_to_checksum.R
@@ -23,9 +23,7 @@ test_that("digest_to_checksum() works", {
     expect_false(checksums[1] == checksums[2])
 
     # .. and on the remote
-    x <- suppressMessages(
-      dplyr::copy_to(conn, x, name = id("test.SCDB_tmp1", conn), overwrite = TRUE, temporary = FALSE)
-    )
+    x <- dplyr::copy_to(conn, x, name = id("test.SCDB_tmp1", conn), overwrite = TRUE, temporary = FALSE)
 
     checksums <- x |> digest_to_checksum() |> dplyr::pull("checksum")
     expect_false(checksums[1] == checksums[2])

--- a/tests/testthat/test-interlace.R
+++ b/tests/testthat/test-interlace.R
@@ -20,18 +20,10 @@ test_that("interlace.tbl_sql() works", {
                         valid_until = as.Date(c("2021-02-01", "2021-03-01", "2021-04-01", NA)))
 
 
-    # Copy t1, t2 and t_ref to conn (and suppress check_from message)
-    t1 <- suppressMessages(
-      dplyr::copy_to(conn, t1, name = id("test.SCDB_tmp1", conn), overwrite = TRUE, temporary = FALSE)
-    )
-
-    t2 <- suppressMessages(
-      dplyr::copy_to(conn, t2, name = id("test.SCDB_tmp2", conn), overwrite = TRUE, temporary = FALSE)
-    )
-
-    t_ref <- suppressMessages(
-      dplyr::copy_to(conn, t_ref, name = id("test.SCDB_tmp3", conn), overwrite = TRUE, temporary = FALSE)
-    )
+    # Copy t1, t2 and t_ref to conn
+    t1 <- dplyr::copy_to(conn, t1, name = id("test.SCDB_tmp1", conn), overwrite = TRUE, temporary = FALSE)
+    t2 <- dplyr::copy_to(conn, t2, name = id("test.SCDB_tmp2", conn), overwrite = TRUE, temporary = FALSE)
+    t_ref <- dplyr::copy_to(conn, t_ref, name = id("test.SCDB_tmp3", conn), overwrite = TRUE, temporary = FALSE)
 
 
     # Order of records may be different, so we arrange then check if they are identical

--- a/tests/testthat/test-update_snapshot.R
+++ b/tests/testthat/test-update_snapshot.R
@@ -10,10 +10,8 @@ test_that("update_snapshot() works", {
       dplyr::mutate(from_ts  = !!db_timestamp("2022-10-01 09:00:00", conn),
                     until_ts = !!db_timestamp(NA, conn))
 
-    # Copy target to conn (and suppress check_from message)
-    target <- suppressMessages(
-      dplyr::copy_to(conn, target, name = id("test.SCDB_tmp1", conn), overwrite = TRUE, temporary = FALSE)
-    )
+    # Copy target to conn
+    target <- dplyr::copy_to(conn, target, name = id("test.SCDB_tmp1", conn), overwrite = TRUE, temporary = FALSE)
 
     .data <- mtcars |>
       dplyr::mutate(hp = dplyr::if_else(hp > 130, hp - 10, hp)) |>
@@ -159,16 +157,10 @@ test_that("update_snapshot() works", {
     t1 <- data.frame(col1 = c("A", "B", "C"), col2 = c(1,        NA_real_, NA_real_))
     t2 <- data.frame(col1 = c("A", "B", "C"), col2 = c(1,        2,        3))
 
-    # Copy t0, t1, and t2 to conn (and suppress check_from message)
-    t0 <- suppressMessages(
-      dplyr::copy_to(conn, t0, name = id("test.SCDB_t0", conn), overwrite = TRUE, temporary = FALSE)
-    )
-    t1 <- suppressMessages(
-      dplyr::copy_to(conn, t1, name = id("test.SCDB_t1", conn), overwrite = TRUE, temporary = FALSE)
-    )
-    t2 <- suppressMessages(
-      dplyr::copy_to(conn, t2, name = id("test.SCDB_t2", conn), overwrite = TRUE, temporary = FALSE)
-    )
+    # Copy t0, t1, and t2 to conn
+    t0 <- dplyr::copy_to(conn, t0, name = id("test.SCDB_t0", conn), overwrite = TRUE, temporary = FALSE)
+    t1 <- dplyr::copy_to(conn, t1, name = id("test.SCDB_t1", conn), overwrite = TRUE, temporary = FALSE)
+    t2 <- dplyr::copy_to(conn, t2, name = id("test.SCDB_t2", conn), overwrite = TRUE, temporary = FALSE)
 
 
     update_snapshot(t0, conn, "test.SCDB_tmp1", "2022-01-01", logger = logger)


### PR DESCRIPTION
<!-- Thanks for contributing!

Before creating your pull request, please read this comment in its entirety.
This will help with reviewing the changes and hopefully merge your changes into
the repository as smoothly as possible.


# Pull request title

Your title should be short yet exhaustive. Hopefully, this comes easily,
as pull requests should be single-topic as possible.


# Issue references
Ideally, the PR addresses an issue. If so, please reference the issue number
in the PR title and/or the body text. See also "Linking a pull request to an issue"
linked in the "Intent" section.


# Automated tests
The package supports several backends, and tests the coverage of these.
If the pull request modifies code which is used by multiple backends, please
test the changes locally before submitting a pull request if possible.
-->

### Intent
This PR removes the use of `suppressMessages()` which was used to suppress the many `dbplyr` messages regarding the `check_from` argument. 

Since dbplyr v2.5, this argument is deprecated and the messages have stopped appearing. 

### Approach
N/A

### Known issues
N/A

### Checklist

* [x] The PR passes all local unit tests
* [ ] I have documented any new features introduced
* [ ] If the PR adds a new feature, please add an entry in `NEWS.md`
* [ ] A reviewer is assigned to this PR
