### PR TITLE
fix(db_joins): Allow dplyr::join_by as by argument

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 * `update_snapshot()` has been optimized and now runs faster on all the supported backends (#137).
 
+* `*_joins()` can now take `dplyr::join_by()` as `by` argument (#156).
+
 ## Documentation
 
 * A vignette including benchmarks of `update_snapshot()` across various backends is added (#138).

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 
 * `update_snapshot()` has been optimized and now runs faster on all the supported backends (#137).
 
-* `*_joins()` can now take `dplyr::join_by()` as `by` argument (#156).
+* `*_joins()` can now take `dplyr::join_by()` as `by` argument when no `na_by` argument is given (#156).
 
 ## Documentation
 

--- a/R/db_joins.R
+++ b/R/db_joins.R
@@ -175,8 +175,10 @@ inner_join.tbl_sql <- function(x, y, by = NULL, ...) {
   # Check arguments
   assert_data_like(x)
   assert_data_like(y)
-  checkmate::assert_character(by, null.ok = TRUE)
-
+  checkmate::assert(
+    checkmate::check_character(by, null.ok = TRUE),
+    checkmate::check_class(by, "dplyr_join_by", null.ok = TRUE)
+  )
   .dots <- list(...)
 
   if (!"na_by" %in% names(.dots)) {
@@ -209,7 +211,10 @@ left_join.tbl_sql <- function(x, y, by = NULL, ...) {
   # Check arguments
   assert_data_like(x)
   assert_data_like(y)
-  checkmate::assert_character(by, null.ok = TRUE)
+  checkmate::assert(
+    checkmate::check_character(by, null.ok = TRUE),
+    checkmate::check_class(by, "dplyr_join_by", null.ok = TRUE)
+  )
 
   .dots <- list(...)
 
@@ -244,7 +249,10 @@ right_join.tbl_sql <- function(x, y, by = NULL, ...) {
   # Check arguments
   assert_data_like(x)
   assert_data_like(y)
-  checkmate::assert_character(by, null.ok = TRUE)
+  checkmate::assert(
+    checkmate::check_character(by, null.ok = TRUE),
+    checkmate::check_class(by, "dplyr_join_by", null.ok = TRUE)
+  )
 
   .dots <- list(...)
 
@@ -280,7 +288,10 @@ full_join.tbl_sql <- function(x, y, by = NULL, ...) {
   # Check arguments
   assert_data_like(x)
   assert_data_like(y)
-  checkmate::assert_character(by, null.ok = TRUE)
+  checkmate::assert(
+    checkmate::check_character(by, null.ok = TRUE),
+    checkmate::check_class(by, "dplyr_join_by", null.ok = TRUE)
+  )
 
   .dots <- list(...)
 
@@ -304,7 +315,10 @@ semi_join.tbl_sql <- function(x, y, by = NULL, ...) {
   # Check arguments
   assert_data_like(x)
   assert_data_like(y)
-  checkmate::assert_character(by, null.ok = TRUE)
+  checkmate::assert(
+    checkmate::check_character(by, null.ok = TRUE),
+    checkmate::check_class(by, "dplyr_join_by", null.ok = TRUE)
+  )
 
   .dots <- list(...)
 
@@ -324,7 +338,10 @@ anti_join.tbl_sql <- function(x, y, by = NULL, ...) {
   # Check arguments
   assert_data_like(x)
   assert_data_like(y)
-  checkmate::assert_character(by, null.ok = TRUE)
+  checkmate::assert(
+    checkmate::check_character(by, null.ok = TRUE),
+    checkmate::check_class(by, "dplyr_join_by", null.ok = TRUE)
+  )
 
   .dots <- list(...)
 

--- a/R/db_joins.R
+++ b/R/db_joins.R
@@ -171,20 +171,18 @@ join_warn_experimental <- function() {
 #' @seealso [dplyr::show_query]
 #' @exportS3Method dplyr::inner_join
 inner_join.tbl_sql <- function(x, y, by = NULL, ...) {
+  .dots <- list(...)
+
+  if (!"na_by" %in% names(.dots)) {
+    join_warn()
+    return(NextMethod("inner_join"))
+  }
 
   # Check arguments
-  assert_data_like(x)
-  assert_data_like(y)
   checkmate::assert(
     checkmate::check_character(by, null.ok = TRUE),
     checkmate::check_class(by, "dplyr_join_by", null.ok = TRUE)
   )
-  .dots <- list(...)
-
-  if (!"na_by" %in% names(.dots)) {
-    if (inherits(x, "tbl_dbi") || inherits(y, "tbl_dbi")) join_warn()
-    return(NextMethod("inner_join"))
-  }
 
   join_warn_experimental()
 
@@ -207,22 +205,18 @@ inner_join.tbl_sql <- function(x, y, by = NULL, ...) {
 #' @rdname joins
 #' @exportS3Method dplyr::left_join
 left_join.tbl_sql <- function(x, y, by = NULL, ...) {
+  .dots <- list(...)
+
+  if (!"na_by" %in% names(.dots)) {
+    join_warn()
+    return(NextMethod("left_join"))
+  }
 
   # Check arguments
-  assert_data_like(x)
-  assert_data_like(y)
   checkmate::assert(
     checkmate::check_character(by, null.ok = TRUE),
     checkmate::check_class(by, "dplyr_join_by", null.ok = TRUE)
   )
-
-  .dots <- list(...)
-
-  if (!"na_by" %in% names(.dots)) {
-    if (inherits(x, "tbl_dbi") || inherits(y, "tbl_dbi")) join_warn()
-
-    return(NextMethod("left_join"))
-  }
 
   join_warn_experimental()
 
@@ -245,22 +239,18 @@ left_join.tbl_sql <- function(x, y, by = NULL, ...) {
 #' @rdname joins
 #' @exportS3Method dplyr::right_join
 right_join.tbl_sql <- function(x, y, by = NULL, ...) {
+  .dots <- list(...)
+
+  if (!"na_by" %in% names(.dots)) {
+    join_warn()
+    return(NextMethod("right_join"))
+  }
 
   # Check arguments
-  assert_data_like(x)
-  assert_data_like(y)
   checkmate::assert(
     checkmate::check_character(by, null.ok = TRUE),
     checkmate::check_class(by, "dplyr_join_by", null.ok = TRUE)
   )
-
-  .dots <- list(...)
-
-  if (!"na_by" %in% names(.dots)) {
-    if (inherits(x, "tbl_dbi") || inherits(y, "tbl_dbi")) join_warn()
-
-    return(NextMethod("right_join"))
-  }
 
   join_warn_experimental()
 
@@ -284,71 +274,54 @@ right_join.tbl_sql <- function(x, y, by = NULL, ...) {
 #' @rdname joins
 #' @exportS3Method dplyr::full_join
 full_join.tbl_sql <- function(x, y, by = NULL, ...) {
+  .dots <- list(...)
+
+  if (!"na_by" %in% names(.dots)) {
+    join_warn()
+    return(NextMethod("full_join"))
+  }
 
   # Check arguments
-  assert_data_like(x)
-  assert_data_like(y)
   checkmate::assert(
     checkmate::check_character(by, null.ok = TRUE),
     checkmate::check_class(by, "dplyr_join_by", null.ok = TRUE)
   )
 
-  .dots <- list(...)
+  join_warn_experimental()
 
-  if ("na_by" %in% names(.dots)) {
-    join_warn_experimental()
-    # Full joins are hard...
-    out <- dplyr::union(dplyr::left_join(x, y, by = by, na_by = .dots$na_by),
-                        dplyr::right_join(x, y, by = by, na_by = .dots$na_by))
-    return(out)
-  } else {
-    if (inherits(x, "tbl_dbi") || inherits(y, "tbl_dbi")) join_warn()
-    return(dplyr::full_join(x, y, by = by, ...))
-  }
+  # Full joins are hard...
+  out <- dplyr::union(
+    dplyr::left_join(x, y, by = by, na_by = .dots$na_by),
+    dplyr::right_join(x, y, by = by, na_by = .dots$na_by)
+  )
+
+  return(out)
 }
 
 
 #' @rdname joins
 #' @exportS3Method dplyr::semi_join
 semi_join.tbl_sql <- function(x, y, by = NULL, ...) {
-
-  # Check arguments
-  assert_data_like(x)
-  assert_data_like(y)
-  checkmate::assert(
-    checkmate::check_character(by, null.ok = TRUE),
-    checkmate::check_class(by, "dplyr_join_by", null.ok = TRUE)
-  )
-
   .dots <- list(...)
 
-  if ("na_by" %in% names(.dots)) {
-    stop("Not implemented")
-  } else {
-    if (inherits(x, "tbl_dbi") || inherits(y, "tbl_dbi")) join_warn()
-    return(dplyr::semi_join(x, y, by = by, ...))
+  if (!"na_by" %in% names(.dots)) {
+    join_warn()
+    return(NextMethod("semi_join"))
   }
+
+  stop("Not implemented")
 }
 
 
 #' @rdname joins
 #' @exportS3Method dplyr::anti_join
 anti_join.tbl_sql <- function(x, y, by = NULL, ...) {
-
-  # Check arguments
-  assert_data_like(x)
-  assert_data_like(y)
-  checkmate::assert(
-    checkmate::check_character(by, null.ok = TRUE),
-    checkmate::check_class(by, "dplyr_join_by", null.ok = TRUE)
-  )
-
   .dots <- list(...)
 
-  if ("na_by" %in% names(.dots)) {
-    stop("Not implemented")
-  } else {
-    if (inherits(x, "tbl_dbi") || inherits(y, "tbl_dbi")) join_warn()
-    return(dplyr::anti_join(x, y, by = by, ...))
+  if (!"na_by" %in% names(.dots)) {
+    join_warn()
+    return(NextMethod("anti_join"))
   }
+
+  stop("Not implemented")
 }

--- a/pak.lock
+++ b/pak.lock
@@ -7,7 +7,7 @@
     {
       "ref": "askpass",
       "package": "askpass",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "type": "standard",
       "direct": false,
       "binary": true,
@@ -19,10 +19,10 @@
         "RemoteRef": "askpass",
         "RemoteRepos": "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
         "RemotePkgPlatform": "x86_64-pc-linux-gnu-ubuntu-22.04",
-        "RemoteSha": "1.2.0"
+        "RemoteSha": "1.2.1"
       },
-      "sources": "https://packagemanager.posit.co/cran/__linux__/jammy/latest/src/contrib/askpass_1.2.0.tar.gz",
-      "target": "src/contrib/x86_64-pc-linux-gnu-ubuntu-22.04/4.4/askpass_1.2.0.tar.gz",
+      "sources": "https://packagemanager.posit.co/cran/__linux__/jammy/latest/src/contrib/askpass_1.2.1.tar.gz",
+      "target": "src/contrib/x86_64-pc-linux-gnu-ubuntu-22.04/4.4/askpass_1.2.1.tar.gz",
       "platform": "x86_64-pc-linux-gnu-ubuntu-22.04",
       "rversion": "4.4",
       "directpkg": false,
@@ -534,7 +534,7 @@
     {
       "ref": "commonmark",
       "package": "commonmark",
-      "version": "1.9.1",
+      "version": "1.9.2",
       "type": "standard",
       "direct": false,
       "binary": true,
@@ -546,10 +546,10 @@
         "RemoteRef": "commonmark",
         "RemoteRepos": "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
         "RemotePkgPlatform": "x86_64-pc-linux-gnu-ubuntu-22.04",
-        "RemoteSha": "1.9.1"
+        "RemoteSha": "1.9.2"
       },
-      "sources": "https://packagemanager.posit.co/cran/__linux__/jammy/latest/src/contrib/commonmark_1.9.1.tar.gz",
-      "target": "src/contrib/x86_64-pc-linux-gnu-ubuntu-22.04/4.4/commonmark_1.9.1.tar.gz",
+      "sources": "https://packagemanager.posit.co/cran/__linux__/jammy/latest/src/contrib/commonmark_1.9.2.tar.gz",
+      "target": "src/contrib/x86_64-pc-linux-gnu-ubuntu-22.04/4.4/commonmark_1.9.2.tar.gz",
       "platform": "x86_64-pc-linux-gnu-ubuntu-22.04",
       "rversion": "4.4",
       "directpkg": false,
@@ -702,7 +702,7 @@
     {
       "ref": "data.table",
       "package": "data.table",
-      "version": "1.16.0",
+      "version": "1.16.2",
       "type": "standard",
       "direct": false,
       "binary": true,
@@ -714,10 +714,10 @@
         "RemoteRef": "data.table",
         "RemoteRepos": "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
         "RemotePkgPlatform": "x86_64-pc-linux-gnu-ubuntu-22.04",
-        "RemoteSha": "1.16.0"
+        "RemoteSha": "1.16.2"
       },
-      "sources": "https://packagemanager.posit.co/cran/__linux__/jammy/latest/src/contrib/data.table_1.16.0.tar.gz",
-      "target": "src/contrib/x86_64-pc-linux-gnu-ubuntu-22.04/4.4/data.table_1.16.0.tar.gz",
+      "sources": "https://packagemanager.posit.co/cran/__linux__/jammy/latest/src/contrib/data.table_1.16.2.tar.gz",
+      "target": "src/contrib/x86_64-pc-linux-gnu-ubuntu-22.04/4.4/data.table_1.16.2.tar.gz",
       "platform": "x86_64-pc-linux-gnu-ubuntu-22.04",
       "rversion": "4.4",
       "directpkg": false,
@@ -1012,7 +1012,7 @@
     {
       "ref": "evaluate",
       "package": "evaluate",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "type": "standard",
       "direct": false,
       "binary": true,
@@ -1024,10 +1024,10 @@
         "RemoteRef": "evaluate",
         "RemoteRepos": "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
         "RemotePkgPlatform": "x86_64-pc-linux-gnu-ubuntu-22.04",
-        "RemoteSha": "1.0.0"
+        "RemoteSha": "1.0.1"
       },
-      "sources": "https://packagemanager.posit.co/cran/__linux__/jammy/latest/src/contrib/evaluate_1.0.0.tar.gz",
-      "target": "src/contrib/x86_64-pc-linux-gnu-ubuntu-22.04/4.4/evaluate_1.0.0.tar.gz",
+      "sources": "https://packagemanager.posit.co/cran/__linux__/jammy/latest/src/contrib/evaluate_1.0.1.tar.gz",
+      "target": "src/contrib/x86_64-pc-linux-gnu-ubuntu-22.04/4.4/evaluate_1.0.1.tar.gz",
       "platform": "x86_64-pc-linux-gnu-ubuntu-22.04",
       "rversion": "4.4",
       "directpkg": false,
@@ -1683,7 +1683,7 @@
     {
       "ref": "hunspell",
       "package": "hunspell",
-      "version": "3.0.4",
+      "version": "3.0.5",
       "type": "standard",
       "direct": false,
       "binary": true,
@@ -1695,10 +1695,10 @@
         "RemoteRef": "hunspell",
         "RemoteRepos": "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
         "RemotePkgPlatform": "x86_64-pc-linux-gnu-ubuntu-22.04",
-        "RemoteSha": "3.0.4"
+        "RemoteSha": "3.0.5"
       },
-      "sources": "https://packagemanager.posit.co/cran/__linux__/jammy/latest/src/contrib/hunspell_3.0.4.tar.gz",
-      "target": "src/contrib/x86_64-pc-linux-gnu-ubuntu-22.04/4.4/hunspell_3.0.4.tar.gz",
+      "sources": "https://packagemanager.posit.co/cran/__linux__/jammy/latest/src/contrib/hunspell_3.0.5.tar.gz",
+      "target": "src/contrib/x86_64-pc-linux-gnu-ubuntu-22.04/4.4/hunspell_3.0.5.tar.gz",
       "platform": "x86_64-pc-linux-gnu-ubuntu-22.04",
       "rversion": "4.4",
       "directpkg": false,
@@ -3619,7 +3619,7 @@
     {
       "ref": "spelling",
       "package": "spelling",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "type": "standard",
       "direct": false,
       "binary": true,
@@ -3631,10 +3631,10 @@
         "RemoteRef": "spelling",
         "RemoteRepos": "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
         "RemotePkgPlatform": "x86_64-pc-linux-gnu-ubuntu-22.04",
-        "RemoteSha": "2.3.0"
+        "RemoteSha": "2.3.1"
       },
-      "sources": "https://packagemanager.posit.co/cran/__linux__/jammy/latest/src/contrib/spelling_2.3.0.tar.gz",
-      "target": "src/contrib/x86_64-pc-linux-gnu-ubuntu-22.04/4.4/spelling_2.3.0.tar.gz",
+      "sources": "https://packagemanager.posit.co/cran/__linux__/jammy/latest/src/contrib/spelling_2.3.1.tar.gz",
+      "target": "src/contrib/x86_64-pc-linux-gnu-ubuntu-22.04/4.4/spelling_2.3.1.tar.gz",
       "platform": "x86_64-pc-linux-gnu-ubuntu-22.04",
       "rversion": "4.4",
       "directpkg": false,
@@ -3719,7 +3719,7 @@
     {
       "ref": "sys",
       "package": "sys",
-      "version": "3.4.2",
+      "version": "3.4.3",
       "type": "standard",
       "direct": false,
       "binary": true,
@@ -3731,10 +3731,10 @@
         "RemoteRef": "sys",
         "RemoteRepos": "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
         "RemotePkgPlatform": "x86_64-pc-linux-gnu-ubuntu-22.04",
-        "RemoteSha": "3.4.2"
+        "RemoteSha": "3.4.3"
       },
-      "sources": "https://packagemanager.posit.co/cran/__linux__/jammy/latest/src/contrib/sys_3.4.2.tar.gz",
-      "target": "src/contrib/x86_64-pc-linux-gnu-ubuntu-22.04/4.4/sys_3.4.2.tar.gz",
+      "sources": "https://packagemanager.posit.co/cran/__linux__/jammy/latest/src/contrib/sys_3.4.3.tar.gz",
+      "target": "src/contrib/x86_64-pc-linux-gnu-ubuntu-22.04/4.4/sys_3.4.3.tar.gz",
       "platform": "x86_64-pc-linux-gnu-ubuntu-22.04",
       "rversion": "4.4",
       "directpkg": false,
@@ -4340,7 +4340,7 @@
     {
       "ref": "xfun",
       "package": "xfun",
-      "version": "0.47",
+      "version": "0.48",
       "type": "standard",
       "direct": false,
       "binary": true,
@@ -4352,10 +4352,10 @@
         "RemoteRef": "xfun",
         "RemoteRepos": "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
         "RemotePkgPlatform": "x86_64-pc-linux-gnu-ubuntu-22.04",
-        "RemoteSha": "0.47"
+        "RemoteSha": "0.48"
       },
-      "sources": "https://packagemanager.posit.co/cran/__linux__/jammy/latest/src/contrib/xfun_0.47.tar.gz",
-      "target": "src/contrib/x86_64-pc-linux-gnu-ubuntu-22.04/4.4/xfun_0.47.tar.gz",
+      "sources": "https://packagemanager.posit.co/cran/__linux__/jammy/latest/src/contrib/xfun_0.48.tar.gz",
+      "target": "src/contrib/x86_64-pc-linux-gnu-ubuntu-22.04/4.4/xfun_0.48.tar.gz",
       "platform": "x86_64-pc-linux-gnu-ubuntu-22.04",
       "rversion": "4.4",
       "directpkg": false,

--- a/tests/testthat/test-db_joins.R
+++ b/tests/testthat/test-db_joins.R
@@ -1,4 +1,4 @@
-test_that("*_join() works", {
+test_that("*_join() works with character `by` and `na_by`", {
   for (conn in get_test_conns()) {
 
     # Define two test datasets
@@ -111,6 +111,35 @@ test_that("*_join() works", {
                  dplyr::left_join(x,  x,  na_by = "name") |>
                    dplyr::select(!"name") |>
                    dplyr::collect())
+
+    connection_clean_up(conn)
+  }
+})
+
+
+test_that("*_join() works with `dplyr::join_by()`", {
+  for (conn in get_test_conns()) {
+
+    # Define two test datasets
+    x <- get_table(conn, "__mtcars") |>
+      dplyr::select(name, mpg, cyl, hp, vs, am, gear, carb)
+
+    y <- get_table(conn, "__mtcars") |>
+      dplyr::select(name, drat, wt, qsec)
+
+
+    # Test the implemented joins
+    q  <- dplyr::left_join(x, y, by = dplyr::join_by(x$name == y$name)) |> dplyr::collect()
+    qr <- dplyr::left_join(dplyr::collect(x), dplyr::collect(y), by = dplyr::join_by(x$name == y$name))
+    expect_equal(q, qr)
+
+    q  <- dplyr::right_join(x, y, by = dplyr::join_by(x$name == y$name)) |> dplyr::collect()
+    qr <- dplyr::right_join(dplyr::collect(x), dplyr::collect(y), by = dplyr::join_by(x$name == y$name))
+    expect_equal(q, qr)
+
+    q  <- dplyr::inner_join(x, y, by = dplyr::join_by(x$name == y$name)) |> dplyr::collect()
+    qr <- dplyr::inner_join(dplyr::collect(x), dplyr::collect(y), by = dplyr::join_by(x$name == y$name))
+    expect_equal(q, qr)
 
     connection_clean_up(conn)
   }

--- a/tests/testthat/test-db_joins.R
+++ b/tests/testthat/test-db_joins.R
@@ -1,28 +1,6 @@
 test_that("*_join() works with character `by` and `na_by`", {
   for (conn in get_test_conns()) {
 
-    # Define two test datasets
-    x <- get_table(conn, "__mtcars") |>
-      dplyr::select(name, mpg, cyl, hp, vs, am, gear, carb)
-
-    y <- get_table(conn, "__mtcars") |>
-      dplyr::select(name, drat, wt, qsec)
-
-
-    # Test the implemented joins
-    q  <- dplyr::left_join(x, y, by = "name") |> dplyr::collect()
-    qr <- dplyr::left_join(dplyr::collect(x), dplyr::collect(y), by = "name")
-    expect_equal(q, qr)
-
-    q <- dplyr::right_join(x, y, by = "name") |> dplyr::collect()
-    qr <- dplyr::right_join(dplyr::collect(x), dplyr::collect(y), by = "name")
-    expect_equal(q, qr)
-
-    q <- dplyr::inner_join(x, y, by = "name") |> dplyr::collect()
-    qr <- dplyr::inner_join(dplyr::collect(x), dplyr::collect(y), by = "name")
-    expect_equal(q, qr)
-
-
     # Create two more synthetic test data set with NA data
 
     # First test case
@@ -139,6 +117,70 @@ test_that("*_join() works with `dplyr::join_by()`", {
 
     q  <- dplyr::inner_join(x, y, by = dplyr::join_by(x$name == y$name)) |> dplyr::collect()
     qr <- dplyr::inner_join(dplyr::collect(x), dplyr::collect(y), by = dplyr::join_by(x$name == y$name))
+    expect_equal(q, qr)
+
+    connection_clean_up(conn)
+  }
+})
+
+
+test_that("*_join() does not break any dplyr joins", {
+  for (conn in get_test_conns()) {
+
+    # Define two test datasets
+    x <- get_table(conn, "__mtcars") |>
+      dplyr::select(name, mpg, cyl, hp, vs, am, gear, carb)
+
+    y <- get_table(conn, "__mtcars") |>
+      dplyr::select(name, drat, wt, qsec)
+
+    # Test the standard joins
+    # left_join
+    qr <- dplyr::left_join(dplyr::collect(x), dplyr::collect(y), by = "name")
+    q  <- dplyr::left_join(x, y, by = "name") |> dplyr::collect()
+    expect_equal(q, qr)
+
+    q <- dplyr::left_join(x, y, by = dplyr::join_by(x$name == y$name)) |> dplyr::collect()
+    expect_equal(q, qr)
+
+    # right_join
+    qr <- dplyr::right_join(dplyr::collect(x), dplyr::collect(y), by = "name")
+    q  <- dplyr::right_join(x, y, by = "name") |> dplyr::collect()
+    expect_equal(q, qr)
+
+    q <- dplyr::right_join(x, y, by = dplyr::join_by(x$name == y$name)) |> dplyr::collect()
+    expect_equal(q, qr)
+
+    # inner_join
+    qr <- dplyr::inner_join(dplyr::collect(x), dplyr::collect(y), by = "name")
+    q  <- dplyr::inner_join(x, y, by = "name") |> dplyr::collect()
+    expect_equal(q, qr)
+
+    q <- dplyr::inner_join(x, y, by = dplyr::join_by(x$name == y$name)) |> dplyr::collect()
+    expect_equal(q, qr)
+
+    # full_join
+    qr <- dplyr::full_join(dplyr::collect(x), dplyr::collect(y), by = "name")
+    q  <- dplyr::full_join(x, y, by = "name") |> dplyr::collect()
+    expect_equal(q, qr)
+
+    q <- dplyr::full_join(x, y, by = dplyr::join_by(x$name == y$name)) |> dplyr::collect()
+    expect_equal(q, qr)
+
+    # semi_join
+    qr <- dplyr::semi_join(dplyr::collect(x), dplyr::collect(y), by = "name")
+    q <- dplyr::semi_join(x, y, by = "name") |> dplyr::collect()
+    expect_equal(q, qr)
+
+    q <- dplyr::semi_join(x, y, by = dplyr::join_by(x$name == y$name)) |> dplyr::collect()
+    expect_equal(q, qr)
+
+    # anti_join
+    qr <- dplyr::anti_join(dplyr::collect(x), dplyr::collect(y), by = "name")
+    q <- dplyr::anti_join(x, y, by = "name") |> dplyr::collect()
+    expect_equal(q, qr)
+
+    q <- dplyr::anti_join(x, y, by = dplyr::join_by(x$name == y$name)) |> dplyr::collect()
     expect_equal(q, qr)
 
     connection_clean_up(conn)


### PR DESCRIPTION
<!-- Thanks for contributing!

Before creating your pull request, please read this comment in its entirety.
This will help with reviewing the changes and hopefully merge your changes into
the repository as smoothly as possible.


# Pull request title

Your title should be short yet exhaustive. Hopefully, this comes easily,
as pull requests should be single-topic as possible.


# Issue references
Ideally, the PR addresses an issue. If so, please reference the issue number
in the PR title and/or the body text. See also "Linking a pull request to an issue"
linked in the "Intent" section.


# Automated tests
The package supports several backends, and tests the coverage of these.
If the pull request modifies code which is used by multiple backends, please
test the changes locally before submitting a pull request if possible.
-->

### Intent
In SCDB, we extend the `dplyr` joins for database backends. 

These extensions include a waning for non-database users that joins work differently from R when joining on NA values.

Since writing these functions, `dplyr` now allows for a `dplyr::join_by` object to be passed as the `by` argument.

This PR allows this type of input.

### Approach
`checkmate` checks are bypassed when the original `dplyr` /  `dbplyr` functions are used

In addition some checks are removed since we know that the data has the required format from the S3 dispatch.

### Known issues
N/A

### Checklist

* [x] The PR passes all local unit tests
* [ ] I have documented any new features introduced
* [x] If the PR adds a new feature, please add an entry in `NEWS.md`
* [x] A reviewer is assigned to this PR
