### PR TITLE
 Fixing update snapshot hanging

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Authors@R:
         person(
             "Lasse Engbo", "Christiansen",
             email = "lsec@ssi.dk",
-            role = "rev",
+            role = c("rev", "ctb"),
             comment = c(ORCID = "0000-0001-5019-1931")
         ),
         person("Sofia Myrup", "Otero", , "smot@ssi.dk", role = "rev"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # SCDB (development version)
 
+## Improvements and Fixes
+
+* A bug was fixed in `update_snapshot()` where the process would unexpectedly hang (#192).
+
 # SCDB 0.5.1
 
 ## BREAKING CHANGES

--- a/R/update_snapshot.R
+++ b/R/update_snapshot.R
@@ -191,6 +191,7 @@ update_snapshot <- function(.data, conn, db_table, timestamp, filters = NULL, me
   .data <- digest_to_checksum(.data, col = "checksum")
   if (!inherits(conn, "SQLiteConnection")) .data <- dplyr::compute(.data) # SQLite was computed in digest_to_checksum
   defer_db_cleanup(.data)
+  logger$log_info("Calculated checksums")
 
   ### Determine the next timestamp in the data (can be NA if none is found)
   next_timestamp <- min(
@@ -247,7 +248,6 @@ update_snapshot <- function(.data, conn, db_table, timestamp, filters = NULL, me
     by = "checksum",
     update_values = c("until_ts" = slice_ts)
   )
-  logger$log_info("After to_remove")
 
   # Commit changes to DB
   rs_deactivate <- DBI::dbSendQuery(conn, sql_deactivate)
@@ -278,7 +278,6 @@ update_snapshot <- function(.data, conn, db_table, timestamp, filters = NULL, me
     by = c("checksum", "from_ts"),
     conflict = "ignore"
   )
-  logger$log_info("After to_add")
 
   # Commit changes to DB
   rs_insert <- DBI::dbSendQuery(conn, sql_insert)

--- a/R/update_snapshot.R
+++ b/R/update_snapshot.R
@@ -229,7 +229,9 @@ update_snapshot <- function(.data, conn, db_table, timestamp, filters = NULL, me
   slice_ts <- db_timestamp(timestamp, conn)
 
   currently_valid_checksums <- db_table %>%
-    dplyr::select("checksum")
+    dplyr::select("checksum") %>%
+    dplyr::compute()
+  defer_db_cleanup(currently_valid_checksums)
 
 
   ## Deactivation

--- a/man/SCDB-package.Rd
+++ b/man/SCDB-package.Rd
@@ -29,7 +29,7 @@ Authors:
 
 Other contributors:
 \itemize{
-  \item Lasse Engbo Christiansen \email{lsec@ssi.dk} (\href{https://orcid.org/0000-0001-5019-1931}{ORCID}) [reviewer]
+  \item Lasse Engbo Christiansen \email{lsec@ssi.dk} (\href{https://orcid.org/0000-0001-5019-1931}{ORCID}) [reviewer, contributor]
   \item Sofia Myrup Otero \email{smot@ssi.dk} [reviewer]
   \item Kim Daniel Jacobsen [contributor]
   \item Statens Serum Institut [copyright holder, funder]

--- a/pak.lock
+++ b/pak.lock
@@ -1917,7 +1917,7 @@
     {
       "ref": "httr2",
       "package": "httr2",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "type": "standard",
       "direct": false,
       "binary": true,
@@ -1929,10 +1929,10 @@
         "RemoteRef": "httr2",
         "RemoteRepos": "https://packagemanager.posit.co/cran/__linux__/noble/latest",
         "RemotePkgPlatform": "x86_64-pc-linux-gnu-ubuntu-24.04",
-        "RemoteSha": "1.1.1"
+        "RemoteSha": "1.1.2"
       },
-      "sources": "https://packagemanager.posit.co/cran/__linux__/noble/latest/src/contrib/httr2_1.1.1.tar.gz",
-      "target": "src/contrib/x86_64-pc-linux-gnu-ubuntu-24.04/4.4/httr2_1.1.1.tar.gz",
+      "sources": "https://packagemanager.posit.co/cran/__linux__/noble/latest/src/contrib/httr2_1.1.2.tar.gz",
+      "target": "src/contrib/x86_64-pc-linux-gnu-ubuntu-24.04/4.4/httr2_1.1.2.tar.gz",
       "platform": "x86_64-pc-linux-gnu-ubuntu-24.04",
       "rversion": "4.4",
       "directpkg": false,


### PR DESCRIPTION
At random update_snapshot hangs after writing "After to_add". This is issue #191 

### Intent
Solves issue #191 

Additional log_info output is adjusted to reduce lines that comes after almost zero computation time.

### Approach
The issue was resolved by adding a compute of currently_valid_checksums.

### Known issues
N/A

### Checklist

* [x] The PR passes all local unit tests
* [x] I have documented any new features introduced
* [ ] If the PR adds a new feature, please add an entry in `NEWS.md`
* [x] A reviewer is assigned to this PR
