### PR TITLE
Investigating SQL Server 2022 issue

### DIFF
--- a/tests/testthat/test-getTableSignature.R
+++ b/tests/testthat/test-getTableSignature.R
@@ -284,8 +284,10 @@ for (conn in c(list(NULL), get_test_conns())) {
 
   if (inherits(conn, "Microsoft SQL Server")) {
     test_that("getTableSignature() generates signature for random data on remote (Microsoft SQL Server)", {
+      tt <- getTableSignature(dplyr::copy_to(conn, data_random), conn)
+      print(tt)
       expect_identical(
-        getTableSignature(dplyr::copy_to(conn, data_random), conn),
+        tt,
         c(
           "Date"      = "DATE",
           "POSIXct"   = "DATETIME",


### PR DESCRIPTION
SQL Server 2022 courses a problem with getTableSignature. The reason may be an update in the CI version of SQL Server 2022.

### Intent
Fix datatypes so that SQL Server 2022 is still supported.



### Known issues

### Checklist

* [ ] The PR passes all local unit tests
* [ ] I have documented any new features introduced
* [ ] If the PR adds a new feature, please add an entry in `NEWS.md`
* [ ] A reviewer is assigned to this PR
