### PR TITLE
Fix for upcoming dbplyr 2.6.0 release

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,7 @@ Depends:
 Imports:
     checkmate,
     DBI,
-    dbplyr (>= 2.4.0),
+    dbplyr (>= 2.5.0),
     dplyr,
     glue,
     lubridate,

--- a/R/id.R
+++ b/R/id.R
@@ -104,31 +104,15 @@ id.tbl_dbi <- function(db_table, ...) {
   }
 
   table_ident <- dbplyr::remote_table(db_table)
+  components  <- dbplyr::table_path_components(table_ident, table_conn)[[1]]
 
-  if (inherits(table_ident, "dbplyr_table_path")) { # dbplyr >= 2.5.0
-    components <- dbplyr::table_path_components(table_ident, table_conn)[[1]]
-
-    components <- components[rev(seq_along(components))] # Reverse order (table, schema?, catalog?)
-
-    if (length(components) > 3) {
-      stop("Unknown table specification", call. = FALSE)
-    }
-
-    table <- purrr::pluck(components, 1)
-    schema <- purrr::pluck(components, 2)
-    catalog <- purrr::pluck(components, 3)
-
-  } else {
-
-    table_ident <- table_ident %>%
-      unclass() %>%
-      purrr::discard(is.na)
-
-    catalog <- purrr::pluck(table_ident, "catalog")
-    schema <- purrr::pluck(table_ident, "schema")
-    table <- purrr::pluck(table_ident, "table")
-
+  if (length(components) > 3) {
+    stop("Unknown table specification", call. = FALSE)
   }
+
+  catalog <- purrr::pluck(components, 1)
+  schema  <- purrr::pluck(components, 2)
+  table   <- purrr::pluck(components, 3)
 
   # Match against known tables
   # In some cases, tables may have been added to the database that makes the id ambiguous.


### PR DESCRIPTION
Given that 2.5.0 has been out for a while, I think you can unconditionally depend on it and then always use `table_path_components()`. That also works in 2.6.0 which has made a few changes to the representation of table paths.
